### PR TITLE
Change navigation drawer to not call delegate when item/subitem is disabled

### DIFF
--- a/NatDS.podspec
+++ b/NatDS.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = "NatDS"
-  s.version       = "0.0.3"
+  s.version       = "0.0.4"
   s.summary       = "Natura Group Design System"
   s.description   = <<-DESC
                     Natura Design System helps designers and developers work faster and smarter, ensuring brand consistency and scalability.

--- a/Tests/Components/NavigationDrawer/Mock/NavigationDrawerDelegateMock.swift
+++ b/Tests/Components/NavigationDrawer/Mock/NavigationDrawerDelegateMock.swift
@@ -3,6 +3,8 @@
 class NavigationDrawerDelegateMock: NavigationDrawerDelegate {
     var mockNumberOfItems = 1
     var mockNumberOfSubitems = 2
+    var mockDisabledItemState = false
+    var mockDisabledSubitemState = false
 
     var invokedNumberOfItems = 0
     var invokedNumberOfSubitems: (count: Int, parameters: [Int])
@@ -46,11 +48,17 @@ class NavigationDrawerDelegateMock: NavigationDrawerDelegate {
         invokedConfigureItem.count += 1
         invokedConfigureItem.parameters.append((item, index))
         item.title = "Item #\(index)"
+        if mockDisabledItemState {
+            item.state = .disabled
+        }
     }
 
     func configureSubitem(_ subitem: NavigationDrawerSubitemCell, at index: NavigationDrawer.IndexMenu) {
         invokedConfigureSubitem.count += 1
         invokedConfigureSubitem.parameters.append((subitem, index))
         subitem.title = "Subitem #\(index.subitem)"
+        if mockDisabledSubitemState {
+            subitem.state = .disabled
+        }
     }
 }

--- a/Tests/Components/NavigationDrawer/NavigationDrawerTests.swift
+++ b/Tests/Components/NavigationDrawer/NavigationDrawerTests.swift
@@ -59,6 +59,15 @@ class NavigationDrawerTests: FBSnapshotTestCase {
         XCTAssertEqual(delegateMock.invokedDidSelectItem.parameters[0], section)
     }
 
+    func test_didSelectRowAt_whenItIsADisabledItem_doesNotCallDelegateDidSelectItem() {
+        delegateMock.mockDisabledItemState = true
+
+        let section = 0
+        sut.tableView(tableView, didSelectRowAt: IndexPath(row: 0, section: section))
+
+        XCTAssertEqual(delegateMock.invokedDidSelectItem.count, 0)
+    }
+
     func test_didSelectRowAt_whenItIsACollapsedItem_callsDelegateNumberOfSubitems() {
         let section = 0
 
@@ -73,9 +82,7 @@ class NavigationDrawerTests: FBSnapshotTestCase {
     func test_didSelectRowAt_whenItIsAnExpandedItem_numberOfRowsInSectionReturnsOne() {
         let section = 0
         sut.tableView(tableView, didSelectRowAt: IndexPath(row: 0, section: section))
-        tableView.reloadData()
         sut.tableView(tableView, didSelectRowAt: IndexPath(row: 0, section: section))
-        tableView.reloadData()
 
         let numberOfRows = sut.tableView(tableView, numberOfRowsInSection: section)
 
@@ -92,6 +99,16 @@ class NavigationDrawerTests: FBSnapshotTestCase {
         XCTAssertEqual(delegateMock.invokedDidSelectSubitem.count, 1)
         XCTAssertEqual(delegateMock.invokedDidSelectSubitem.parameters[0].item, expectedItem)
         XCTAssertEqual(delegateMock.invokedDidSelectSubitem.parameters[0].subitem, expectedSubitem)
+    }
+
+    func test_didSelectRowAt_whenItIsADisabledSubitem_doesNotCallDelegateDidSelectSubitem() {
+        delegateMock.mockDisabledSubitemState = true
+
+        sut.tableView(tableView, didSelectRowAt: IndexPath(row: 0, section: 0))
+        sut.layoutIfNeeded()
+        sut.tableView(tableView, didSelectRowAt: IndexPath(row: 1, section: 0))
+
+        XCTAssertEqual(delegateMock.invokedDidSelectSubitem.count, 0)
     }
 
     func test_cellForRowAt_whenItIsAnItem_callsDelegateViewForItem() {
@@ -115,10 +132,17 @@ class NavigationDrawerTests: FBSnapshotTestCase {
         XCTAssertEqual(delegateMock.invokedConfigureSubitem.parameters[0].index.subitem, expectedSubitem)
     }
 
+    func test_cellForRowAt_whenItIsASubitem_cellStateIsNormalByDefault() {
+        let indexPath = IndexPath(row: 1, section: 0)
+
+        let cell = sut.tableView(tableView, cellForRowAt: indexPath) as? NavigationDrawerSubitemCell
+
+        XCTAssertEqual(cell?.state, .normal)
+    }
+
     func test_cellForRowAt_whenItIsAnItem_hasValidSnapshot() {
         delegateMock.mockNumberOfItems = 10
         delegateMock.mockNumberOfSubitems = 0
-        tableView.reloadData()
 
         FBSnapshotVerifyView(sut)
     }
@@ -126,7 +150,6 @@ class NavigationDrawerTests: FBSnapshotTestCase {
     func test_cellForRowAt_whenItIsACollapsedItem_hasValidSnapshot() {
         delegateMock.mockNumberOfItems = 10
         delegateMock.mockNumberOfSubitems = 2
-        tableView.reloadData()
 
         FBSnapshotVerifyView(sut)
     }
@@ -136,7 +159,6 @@ class NavigationDrawerTests: FBSnapshotTestCase {
         delegateMock.mockNumberOfSubitems = 2
         sut.tableView(tableView, didSelectRowAt: IndexPath(row: 0, section: 0))
         sut.tableView(tableView, didSelectRowAt: IndexPath(row: 0, section: 4))
-        tableView.reloadData()
 
         FBSnapshotVerifyView(sut)
     }


### PR DESCRIPTION
# Description

Change navigation drawer to not call delegate when item/subitem is disabled

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
