### PR TITLE
Fix size of buttons according to its titles

### DIFF
--- a/Sources/Components/Button/ContainedButton.swift
+++ b/Sources/Components/Button/ContainedButton.swift
@@ -50,7 +50,7 @@ extension ContainedButton {
         layer.cornerRadius = 4.0
 
         titleLabel?.font = Fonts.button
-        titleEdgeInsets = UIEdgeInsets(top: 16, left: 16, bottom: 16, right: 16)
+        contentEdgeInsets = UIEdgeInsets(top: 16, left: 16, bottom: 16, right: 16)
 
         setTitleColor(Colors.Content.highEmphasis, for: .normal)
         setTitleColor(Colors.Content.highEmphasis.withAlphaComponent(0.24), for: .disabled)

--- a/Sources/Components/Button/FlatButton.swift
+++ b/Sources/Components/Button/FlatButton.swift
@@ -39,7 +39,7 @@ private extension FlatButton {
 
         backgroundColor = .clear
         titleLabel?.font = Fonts.button
-        titleEdgeInsets = UIEdgeInsets(top: 16, left: 16, bottom: 16, right: 16)
+        contentEdgeInsets = UIEdgeInsets(top: 16, left: 16, bottom: 16, right: 16)
 
         setTitleColor(Colors.Content.highEmphasis, for: .normal)
         setTitleColor(Colors.Content.highEmphasis.withAlphaComponent(0.48), for: .disabled)

--- a/Tests/Components/Button/ContainedButtonTests.swift
+++ b/Tests/Components/Button/ContainedButtonTests.swift
@@ -31,4 +31,11 @@ class ContainedButtonTests: FBSnapshotTestCase {
         sut.setTitle("ok", for: .normal)
         XCTAssertEqual(sut.titleLabel?.text, "OK")
     }
+
+    func test_contentEdgeInsets_asExpected() {
+        XCTAssertEqual(sut.contentEdgeInsets.top, 16)
+        XCTAssertEqual(sut.contentEdgeInsets.bottom, 16)
+        XCTAssertEqual(sut.contentEdgeInsets.left, 16)
+        XCTAssertEqual(sut.contentEdgeInsets.right, 16)
+    }
 }

--- a/Tests/Components/Button/ContainedButtonTests.swift
+++ b/Tests/Components/Button/ContainedButtonTests.swift
@@ -32,7 +32,7 @@ class ContainedButtonTests: FBSnapshotTestCase {
         XCTAssertEqual(sut.titleLabel?.text, "OK")
     }
 
-    func test_contentEdgeInsets_asExpected() {
+    func test_contentEdgeInsets_allInsetsHaveSixteen() {
         XCTAssertEqual(sut.contentEdgeInsets.top, 16)
         XCTAssertEqual(sut.contentEdgeInsets.bottom, 16)
         XCTAssertEqual(sut.contentEdgeInsets.left, 16)

--- a/Tests/Components/Button/FlatButtonTests.swift
+++ b/Tests/Components/Button/FlatButtonTests.swift
@@ -30,4 +30,11 @@ class FlatButtonTests: FBSnapshotTestCase {
         sut.isEnabled = false
         FBSnapshotVerifyView(superview)
     }
+
+    func test_contentEdgeInsets_asExpected() {
+        XCTAssertEqual(sut.contentEdgeInsets.top, 16)
+        XCTAssertEqual(sut.contentEdgeInsets.bottom, 16)
+        XCTAssertEqual(sut.contentEdgeInsets.left, 16)
+        XCTAssertEqual(sut.contentEdgeInsets.right, 16)
+    }
 }

--- a/Tests/Components/Button/FlatButtonTests.swift
+++ b/Tests/Components/Button/FlatButtonTests.swift
@@ -31,7 +31,7 @@ class FlatButtonTests: FBSnapshotTestCase {
         FBSnapshotVerifyView(superview)
     }
 
-    func test_contentEdgeInsets_asExpected() {
+    func test_contentEdgeInsets_allInsetsHaveSixteen() {
         XCTAssertEqual(sut.contentEdgeInsets.top, 16)
         XCTAssertEqual(sut.contentEdgeInsets.bottom, 16)
         XCTAssertEqual(sut.contentEdgeInsets.left, 16)


### PR DESCRIPTION
# Description

Use `contentEdgeInsets` instead of `titleEdgeInsets` to make button size adapts to its title. This change affects only `FlatButton` and `ContainedButton`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
