### PR TITLE
Replace OutlinedContentHealthy with zOutlinedContentHealth icon

### DIFF
--- a/Sources/Components/Icons/Icon.swift
+++ b/Sources/Components/Icons/Icon.swift
@@ -79,7 +79,7 @@ public enum Icon: String, CaseIterable {
     case outlinedContentEducation = "\u{EA4E}"
     case outlinedContentGift = "\u{EA4F}"
     case outlinedContentGlobal = "\u{EA50}"
-    case outlinedContentHealthy = "\u{EA51}"
+    case outlinedContentHealthy = "\u{EA96}"
     case outlinedContentLock = "\u{EA52}"
     case outlinedContentMagic = "\u{EA53}"
     case outlinedContentMedal = "\u{EA54}"
@@ -149,6 +149,6 @@ public enum Icon: String, CaseIterable {
     case zOutlinedContentBellringing = "\u{EA93}"
     case zOutlinedContentExchangereports = "\u{EA94}"
     case zOutlinedContentGallery = "\u{EA95}"
-    case zOutlinedContentHealth = "\u{EA96}"
+    case zOutlinedContentHealth = "\u{EA51}"
     case zOutlinedContentPlanb = "\u{EA97}"
 }

--- a/Tests/ReferenceImages_64/NatDSTests.IconTests/test_outlinedContentHealthy_hasValidSnapshot@2x.png
+++ b/Tests/ReferenceImages_64/NatDSTests.IconTests/test_outlinedContentHealthy_hasValidSnapshot@2x.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:4999c26988ad61783296a409aba12a8ae4399ff0bcee8804791703fc54787319
-size 1326
+oid sha256:6b46ac3dc39d5ae46f3887e4e5b77ae105e25166fc0488d054e713e2740a05fe
+size 981

--- a/Tests/ReferenceImages_64/NatDSTests.IconTests/test_zOutlinedContentHealth_hasValidSnapshot@2x.png
+++ b/Tests/ReferenceImages_64/NatDSTests.IconTests/test_zOutlinedContentHealth_hasValidSnapshot@2x.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6b46ac3dc39d5ae46f3887e4e5b77ae105e25166fc0488d054e713e2740a05fe
-size 981
+oid sha256:4999c26988ad61783296a409aba12a8ae4399ff0bcee8804791703fc54787319
+size 1326


### PR DESCRIPTION
# Description

Replace OutlinedContentHealthy with zOutlinedContentHealth icon

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
