### PR TITLE
Elevation token

### DIFF
--- a/NatDS.xcodeproj/project.pbxproj
+++ b/NatDS.xcodeproj/project.pbxproj
@@ -204,6 +204,8 @@
 		84BFB66B246DCD1100506ED1 /* TheBodyShopElevations+Spec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84BFB66A246DCD1100506ED1 /* TheBodyShopElevations+Spec.swift */; };
 		84BFB66D246DD12200506ED1 /* AvonElevations+Spec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84BFB66C246DD12200506ED1 /* AvonElevations+Spec.swift */; };
 		84BFB66F246DD15700506ED1 /* NaturaElevations+Spec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84BFB66E246DD15700506ED1 /* NaturaElevations+Spec.swift */; };
+		84BFB671246DF0B300506ED1 /* NatElevations+Spec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84BFB670246DF0B300506ED1 /* NatElevations+Spec.swift */; };
+		84BFB673246DF82800506ED1 /* ElevationAttributes+Equitable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84BFB672246DF82800506ED1 /* ElevationAttributes+Equitable.swift */; };
 		84EE85E9245A0FB20009293A /* NatSpacing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84EE85E8245A0FB20009293A /* NatSpacing.swift */; };
 		A9325A6623FB34EC0023979C /* UICollectionView+Reusable.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9325A6523FB34EC0023979C /* UICollectionView+Reusable.swift */; };
 		A9325A6A23FB35C50023979C /* UICollectionView+ReusableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9325A6723FB35450023979C /* UICollectionView+ReusableTests.swift */; };
@@ -433,6 +435,8 @@
 		84BFB66A246DCD1100506ED1 /* TheBodyShopElevations+Spec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TheBodyShopElevations+Spec.swift"; sourceTree = "<group>"; };
 		84BFB66C246DD12200506ED1 /* AvonElevations+Spec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AvonElevations+Spec.swift"; sourceTree = "<group>"; };
 		84BFB66E246DD15700506ED1 /* NaturaElevations+Spec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NaturaElevations+Spec.swift"; sourceTree = "<group>"; };
+		84BFB670246DF0B300506ED1 /* NatElevations+Spec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NatElevations+Spec.swift"; sourceTree = "<group>"; };
+		84BFB672246DF82800506ED1 /* ElevationAttributes+Equitable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ElevationAttributes+Equitable.swift"; sourceTree = "<group>"; };
 		84EE85E8245A0FB20009293A /* NatSpacing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NatSpacing.swift; sourceTree = "<group>"; };
 		9A46395C038D4497A880A6FF /* Pods-NatDSTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NatDSTests.release.xcconfig"; path = "Target Support Files/Pods-NatDSTests/Pods-NatDSTests.release.xcconfig"; sourceTree = "<group>"; };
 		A8B18363274C7A70CF4443A3 /* Pods-NatDSTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NatDSTests.debug.xcconfig"; path = "Target Support Files/Pods-NatDSTests/Pods-NatDSTests.debug.xcconfig"; sourceTree = "<group>"; };
@@ -560,6 +564,7 @@
 				843FA2B32464717600D20D9A /* NatOpacities+Spec.swift */,
 				843FA2AF2463624A00D20D9A /* NatBorderRadius+Spec.swift */,
 				84BFB61D24699DB600506ED1 /* NatFonts */,
+				84BFB670246DF0B300506ED1 /* NatElevations+Spec.swift */,
 			);
 			path = DesignTokens;
 			sourceTree = "<group>";
@@ -1061,6 +1066,7 @@
 				8427A2AF244F720B00CF30D5 /* UIColor+AsHexString.swift */,
 				8427A32D2453A8C900CF30D5 /* MockStorage.swift */,
 				84BFB61B2469810600506ED1 /* UIFont+GetWeight.swift */,
+				84BFB672246DF82800506ED1 /* ElevationAttributes+Equitable.swift */,
 			);
 			path = TestingHelpers;
 			sourceTree = "<group>";
@@ -1726,6 +1732,7 @@
 				8427A2D22451DD0400CF30D5 /* AvonColorPaletteDark+Spec.swift in Sources */,
 				8427A30A2452246400CF30D5 /* TheBodyShopColorPaletteLight+Content+Spec.swift in Sources */,
 				8427A2CE2451D15F00CF30D5 /* TheBodyShopTheme+Spec.swift in Sources */,
+				84BFB671246DF0B300506ED1 /* NatElevations+Spec.swift in Sources */,
 				64DF47DF23FB2C7D00DAF441 /* String+IconTests.swift in Sources */,
 				110F55B623BE643A00B9937A /* ContainedButtonTests.swift in Sources */,
 				843FA2BE2464837E00D20D9A /* AvonOpacities+Spec.swift in Sources */,
@@ -1756,6 +1763,7 @@
 				A9CCF8E823CCF03500000FC0 /* FontIconStyleTests.swift in Sources */,
 				117FE016238D9AEB0032E2AC /* ColorsTests.swift in Sources */,
 				642468AB23FDC63B008EAE6B /* TabItemViewTests.swift in Sources */,
+				84BFB673246DF82800506ED1 /* ElevationAttributes+Equitable.swift in Sources */,
 				8427A2EC245211FA00CF30D5 /* TheBodyShopColorPaletteLight+Primary+Spec.swift in Sources */,
 				84BFB61C2469810600506ED1 /* UIFont+GetWeight.swift in Sources */,
 				A9CBAD8523CE535300A46CB2 /* IconTests.swift in Sources */,

--- a/NatDS.xcodeproj/project.pbxproj
+++ b/NatDS.xcodeproj/project.pbxproj
@@ -199,6 +199,11 @@
 		84BFB65F246DA47500506ED1 /* AvonElevations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84BFB65E246DA47500506ED1 /* AvonElevations.swift */; };
 		84BFB661246DA4B400506ED1 /* NaturaElevations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84BFB660246DA4B400506ED1 /* NaturaElevations.swift */; };
 		84BFB663246DA50100506ED1 /* TheBodyShopElevations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84BFB662246DA50100506ED1 /* TheBodyShopElevations.swift */; };
+		84BFB666246DCB5900506ED1 /* ViewStyling.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84BFB665246DCB5900506ED1 /* ViewStyling.swift */; };
+		84BFB669246DCC0800506ED1 /* ViewStyling+Spec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84BFB668246DCC0800506ED1 /* ViewStyling+Spec.swift */; };
+		84BFB66B246DCD1100506ED1 /* TheBodyShopElevations+Spec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84BFB66A246DCD1100506ED1 /* TheBodyShopElevations+Spec.swift */; };
+		84BFB66D246DD12200506ED1 /* AvonElevations+Spec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84BFB66C246DD12200506ED1 /* AvonElevations+Spec.swift */; };
+		84BFB66F246DD15700506ED1 /* NaturaElevations+Spec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84BFB66E246DD15700506ED1 /* NaturaElevations+Spec.swift */; };
 		84EE85E9245A0FB20009293A /* NatSpacing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84EE85E8245A0FB20009293A /* NatSpacing.swift */; };
 		A9325A6623FB34EC0023979C /* UICollectionView+Reusable.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9325A6523FB34EC0023979C /* UICollectionView+Reusable.swift */; };
 		A9325A6A23FB35C50023979C /* UICollectionView+ReusableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9325A6723FB35450023979C /* UICollectionView+ReusableTests.swift */; };
@@ -423,6 +428,11 @@
 		84BFB65E246DA47500506ED1 /* AvonElevations.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AvonElevations.swift; sourceTree = "<group>"; };
 		84BFB660246DA4B400506ED1 /* NaturaElevations.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NaturaElevations.swift; sourceTree = "<group>"; };
 		84BFB662246DA50100506ED1 /* TheBodyShopElevations.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TheBodyShopElevations.swift; sourceTree = "<group>"; };
+		84BFB665246DCB5900506ED1 /* ViewStyling.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewStyling.swift; sourceTree = "<group>"; };
+		84BFB668246DCC0800506ED1 /* ViewStyling+Spec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ViewStyling+Spec.swift"; sourceTree = "<group>"; };
+		84BFB66A246DCD1100506ED1 /* TheBodyShopElevations+Spec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TheBodyShopElevations+Spec.swift"; sourceTree = "<group>"; };
+		84BFB66C246DD12200506ED1 /* AvonElevations+Spec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AvonElevations+Spec.swift"; sourceTree = "<group>"; };
+		84BFB66E246DD15700506ED1 /* NaturaElevations+Spec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NaturaElevations+Spec.swift"; sourceTree = "<group>"; };
 		84EE85E8245A0FB20009293A /* NatSpacing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NatSpacing.swift; sourceTree = "<group>"; };
 		9A46395C038D4497A880A6FF /* Pods-NatDSTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NatDSTests.release.xcconfig"; path = "Target Support Files/Pods-NatDSTests/Pods-NatDSTests.release.xcconfig"; sourceTree = "<group>"; };
 		A8B18363274C7A70CF4443A3 /* Pods-NatDSTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NatDSTests.debug.xcconfig"; path = "Target Support Files/Pods-NatDSTests/Pods-NatDSTests.debug.xcconfig"; sourceTree = "<group>"; };
@@ -892,6 +902,7 @@
 		8427A2BD2451CB1E00CF30D5 /* Core */ = {
 			isa = PBXGroup;
 			children = (
+				84BFB667246DCBE700506ED1 /* ViewStyling */,
 				846313A9245C479F00387FCF /* Configuration */,
 				8427A2C12451CE1D00CF30D5 /* SupportedBrands */,
 			);
@@ -919,6 +930,7 @@
 				843FA2AB24635E9F00D20D9A /* NaturaBorderRadius+Spec.swift */,
 				843FA2BF246483CC00D20D9A /* NaturaOpacities+Spec.swift */,
 				84BFB63C2469C26600506ED1 /* Font */,
+				84BFB66E246DD15700506ED1 /* NaturaElevations+Spec.swift */,
 			);
 			path = Natura;
 			sourceTree = "<group>";
@@ -934,6 +946,7 @@
 				843FA2A924635D7400D20D9A /* AvonBorderRadius+Spec.swift */,
 				843FA2BD2464837E00D20D9A /* AvonOpacities+Spec.swift */,
 				84BFB63B2469C24C00506ED1 /* Font */,
+				84BFB66C246DD12200506ED1 /* AvonElevations+Spec.swift */,
 			);
 			path = Avon;
 			sourceTree = "<group>";
@@ -949,6 +962,7 @@
 				843FA2AD24635EDF00D20D9A /* TheBodyShopBorderRadius+Spec.swift */,
 				843FA2C1246483E500D20D9A /* TheBodyShopOpacities+Spec.swift */,
 				84BFB6422469C9C900506ED1 /* Font */,
+				84BFB66A246DCD1100506ED1 /* TheBodyShopElevations+Spec.swift */,
 			);
 			path = TheBodyShop;
 			sourceTree = "<group>";
@@ -1100,6 +1114,7 @@
 		845D9EF3244DE190003598B0 /* Core */ = {
 			isa = PBXGroup;
 			children = (
+				84BFB664246DCB2B00506ED1 /* ViewStyling */,
 				8427A32A24538DDF00CF30D5 /* Configuration */,
 				8427A28A2447772B00CF30D5 /* Theme */,
 				117FE01A238D9B070032E2AC /* DesignTokens */,
@@ -1220,6 +1235,22 @@
 				84BFB65C246DA42800506ED1 /* ElevationAttributes.swift */,
 			);
 			path = Elevation;
+			sourceTree = "<group>";
+		};
+		84BFB664246DCB2B00506ED1 /* ViewStyling */ = {
+			isa = PBXGroup;
+			children = (
+				84BFB665246DCB5900506ED1 /* ViewStyling.swift */,
+			);
+			path = ViewStyling;
+			sourceTree = "<group>";
+		};
+		84BFB667246DCBE700506ED1 /* ViewStyling */ = {
+			isa = PBXGroup;
+			children = (
+				84BFB668246DCC0800506ED1 /* ViewStyling+Spec.swift */,
+			);
+			path = ViewStyling;
 			sourceTree = "<group>";
 		};
 		84EE85E5245A0E970009293A /* DeprecatedWillBeRemoved */ = {
@@ -1605,6 +1636,7 @@
 				A9CCF8DC23CCDF0100000FC0 /* FontIconStyle.swift in Sources */,
 				4395D1DA23FC6AB700C7DC6F /* Tab.swift in Sources */,
 				A9325A6623FB34EC0023979C /* UICollectionView+Reusable.swift in Sources */,
+				84BFB666246DCB5900506ED1 /* ViewStyling.swift in Sources */,
 				84428F95245B9DE000D46611 /* DesignSystemFatalError.swift in Sources */,
 				84BFB62A2469B93C00506ED1 /* TheBodyShopFontSizes.swift in Sources */,
 				117FE025238D9B070032E2AC /* FontsNatura.swift in Sources */,
@@ -1657,6 +1689,7 @@
 				843FA2C0246483CC00D20D9A /* NaturaOpacities+Spec.swift in Sources */,
 				11581A9B238EC15E003E45D7 /* NavigationDrawerItemCellTests.swift in Sources */,
 				84BFB6402469C2B900506ED1 /* NaturaFontWeights+Spec.swift in Sources */,
+				84BFB66F246DD15700506ED1 /* NaturaElevations+Spec.swift in Sources */,
 				8427A31C24522A4600CF30D5 /* TheBodyShopColorPaletteDark+Feedback+Spec.swift in Sources */,
 				43F1DD4C24183BA0005A0C4A /* PulseLayerTests.swift in Sources */,
 				8427A3102452264700CF30D5 /* TheBodyShopColorPaletteDark+Content+Spec.swift in Sources */,
@@ -1712,6 +1745,7 @@
 				84BFB64C2469CBBC00506ED1 /* AvonFont+Spec.swift in Sources */,
 				64B47D6B240F3D9000E19797 /* FlatButtonTests.swift in Sources */,
 				8427A3022452220100CF30D5 /* NaturaColorPaletteDark+Surface+Spec.swift in Sources */,
+				84BFB669246DCC0800506ED1 /* ViewStyling+Spec.swift in Sources */,
 				8427A2EE245212D400CF30D5 /* AvonColorPaletteLight+Secondary+Spec.swift in Sources */,
 				843FA2B42464717700D20D9A /* NatOpacities+Spec.swift in Sources */,
 				8427A316245229AA00CF30D5 /* NaturaColorPaletteDark+Feedback+Spec.swift in Sources */,
@@ -1749,9 +1783,11 @@
 				8427A3142452296900CF30D5 /* AvonColorPaletteDark+Feedback+Spec.swift in Sources */,
 				8427A2F02452174800CF30D5 /* NaturaColorPaletteLight+Secondary+Spec.swift in Sources */,
 				643ABFF324118BF1000918EA /* PulsableTests.swift in Sources */,
+				84BFB66B246DCD1100506ED1 /* TheBodyShopElevations+Spec.swift in Sources */,
 				11581AA8238F037D003E45D7 /* AssetsHelperTests.swift in Sources */,
 				8427A2DC2451E3F200CF30D5 /* AvonColorPaletteDark+Primary+Spec.swift in Sources */,
 				84428F92245B265000D46611 /* NatSpacing+Spec.swift in Sources */,
+				84BFB66D246DD12200506ED1 /* AvonElevations+Spec.swift in Sources */,
 				8427A2D62451E07700CF30D5 /* NaturaColorPaletteLight+Spec.swift in Sources */,
 				8427A3062452230B00CF30D5 /* AvonColorPaletteLight+Content+Spec.swift in Sources */,
 				117FE015238D9AEB0032E2AC /* ColorsNaturaTests.swift in Sources */,

--- a/NatDS.xcodeproj/project.pbxproj
+++ b/NatDS.xcodeproj/project.pbxproj
@@ -193,6 +193,12 @@
 		84BFB6482469CB9000506ED1 /* TheBodyShopFont+Spec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84BFB6472469CB9000506ED1 /* TheBodyShopFont+Spec.swift */; };
 		84BFB64A2469CBAA00506ED1 /* NaturaFont+Spec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84BFB6492469CBAA00506ED1 /* NaturaFont+Spec.swift */; };
 		84BFB64C2469CBBC00506ED1 /* AvonFont+Spec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84BFB64B2469CBBC00506ED1 /* AvonFont+Spec.swift */; };
+		84BFB652246C276800506ED1 /* NatElevation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84BFB651246C276800506ED1 /* NatElevation.swift */; };
+		84BFB65B246DA40700506ED1 /* Elevations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84BFB65A246DA40700506ED1 /* Elevations.swift */; };
+		84BFB65D246DA42800506ED1 /* ElevationAttributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84BFB65C246DA42800506ED1 /* ElevationAttributes.swift */; };
+		84BFB65F246DA47500506ED1 /* AvonElevations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84BFB65E246DA47500506ED1 /* AvonElevations.swift */; };
+		84BFB661246DA4B400506ED1 /* NaturaElevations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84BFB660246DA4B400506ED1 /* NaturaElevations.swift */; };
+		84BFB663246DA50100506ED1 /* TheBodyShopElevations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84BFB662246DA50100506ED1 /* TheBodyShopElevations.swift */; };
 		84EE85E9245A0FB20009293A /* NatSpacing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84EE85E8245A0FB20009293A /* NatSpacing.swift */; };
 		A9325A6623FB34EC0023979C /* UICollectionView+Reusable.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9325A6523FB34EC0023979C /* UICollectionView+Reusable.swift */; };
 		A9325A6A23FB35C50023979C /* UICollectionView+ReusableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9325A6723FB35450023979C /* UICollectionView+ReusableTests.swift */; };
@@ -411,6 +417,12 @@
 		84BFB6472469CB9000506ED1 /* TheBodyShopFont+Spec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TheBodyShopFont+Spec.swift"; sourceTree = "<group>"; };
 		84BFB6492469CBAA00506ED1 /* NaturaFont+Spec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NaturaFont+Spec.swift"; sourceTree = "<group>"; };
 		84BFB64B2469CBBC00506ED1 /* AvonFont+Spec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AvonFont+Spec.swift"; sourceTree = "<group>"; };
+		84BFB651246C276800506ED1 /* NatElevation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NatElevation.swift; sourceTree = "<group>"; };
+		84BFB65A246DA40700506ED1 /* Elevations.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Elevations.swift; sourceTree = "<group>"; };
+		84BFB65C246DA42800506ED1 /* ElevationAttributes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ElevationAttributes.swift; sourceTree = "<group>"; };
+		84BFB65E246DA47500506ED1 /* AvonElevations.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AvonElevations.swift; sourceTree = "<group>"; };
+		84BFB660246DA4B400506ED1 /* NaturaElevations.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NaturaElevations.swift; sourceTree = "<group>"; };
+		84BFB662246DA50100506ED1 /* TheBodyShopElevations.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TheBodyShopElevations.swift; sourceTree = "<group>"; };
 		84EE85E8245A0FB20009293A /* NatSpacing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NatSpacing.swift; sourceTree = "<group>"; };
 		9A46395C038D4497A880A6FF /* Pods-NatDSTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NatDSTests.release.xcconfig"; path = "Target Support Files/Pods-NatDSTests/Pods-NatDSTests.release.xcconfig"; sourceTree = "<group>"; };
 		A8B18363274C7A70CF4443A3 /* Pods-NatDSTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NatDSTests.debug.xcconfig"; path = "Target Support Files/Pods-NatDSTests/Pods-NatDSTests.debug.xcconfig"; sourceTree = "<group>"; };
@@ -581,6 +593,7 @@
 		117FE01A238D9B070032E2AC /* DesignTokens */ = {
 			isa = PBXGroup;
 			children = (
+				84BFB659246DA3F100506ED1 /* Elevation */,
 				117FE01B238D9B070032E2AC /* Colors */,
 				117FE01F238D9B070032E2AC /* Fonts */,
 				84EE85E7245A0F930009293A /* Spacing */,
@@ -816,6 +829,7 @@
 				843FA2B52464724C00D20D9A /* AvonOpacities.swift */,
 				843FA297246331F000D20D9A /* AvonBorderRadius.swift */,
 				84BFB6342469BEF900506ED1 /* Font */,
+				84BFB65E246DA47500506ED1 /* AvonElevations.swift */,
 			);
 			path = Avon;
 			sourceTree = "<group>";
@@ -841,6 +855,7 @@
 				843FA2BB2464759100D20D9A /* TheBodyShopOpacities.swift */,
 				843FA29B2463369A00D20D9A /* TheBodyShopRadius.swift */,
 				84BFB6262469B90000506ED1 /* Font */,
+				84BFB662246DA50100506ED1 /* TheBodyShopElevations.swift */,
 			);
 			path = TheBodyShop;
 			sourceTree = "<group>";
@@ -869,6 +884,7 @@
 				843FA2B92464757200D20D9A /* NaturaOpacities.swift */,
 				843FA299246335D600D20D9A /* NaturaBorderRadius.swift */,
 				84BFB62D2469BDB900506ED1 /* Font */,
+				84BFB660246DA4B400506ED1 /* NaturaElevations.swift */,
 			);
 			path = Natura;
 			sourceTree = "<group>";
@@ -1066,6 +1082,7 @@
 				843FA2B1246458C400D20D9A /* NatOpacities.swift */,
 				84EE85E8245A0FB20009293A /* NatSpacing.swift */,
 				843FA27A2461D82200D20D9A /* NatSizes.swift */,
+				84BFB651246C276800506ED1 /* NatElevation.swift */,
 			);
 			path = DesignTokens;
 			sourceTree = "<group>";
@@ -1194,6 +1211,15 @@
 				117FE020238D9B070032E2AC /* Branding */,
 			);
 			path = DeprecatedWillBeRemoved;
+			sourceTree = "<group>";
+		};
+		84BFB659246DA3F100506ED1 /* Elevation */ = {
+			isa = PBXGroup;
+			children = (
+				84BFB65A246DA40700506ED1 /* Elevations.swift */,
+				84BFB65C246DA42800506ED1 /* ElevationAttributes.swift */,
+			);
+			path = Elevation;
 			sourceTree = "<group>";
 		};
 		84EE85E5245A0E970009293A /* DeprecatedWillBeRemoved */ = {
@@ -1538,6 +1564,7 @@
 				843FA2B2246458C400D20D9A /* NatOpacities.swift in Sources */,
 				6404360523F45FF00088B20D /* TextField.swift in Sources */,
 				112BAC2523984416009001A7 /* UITableView+Reusable.swift in Sources */,
+				84BFB661246DA4B400506ED1 /* NaturaElevations.swift in Sources */,
 				8427A2A42449F97F00CF30D5 /* SecondaryColorPalette.swift in Sources */,
 				843FA27F2461DDFC00D20D9A /* AvonSizes.swift in Sources */,
 				11FC55BE23C64E8800C91014 /* IllustrationIcons.swift in Sources */,
@@ -1549,8 +1576,10 @@
 				8427A2AC2449FC4E00CF30D5 /* AvonColorPaletteLight.swift in Sources */,
 				84428F83245B03FD00D46611 /* AvonSpacing.swift in Sources */,
 				8427A2B82451C93B00CF30D5 /* NaturaTheme.swift in Sources */,
+				84BFB65B246DA40700506ED1 /* Elevations.swift in Sources */,
 				84BFB6312469BDF400506ED1 /* NaturaFontSizes.swift in Sources */,
 				117FE023238D9B070032E2AC /* ColorsNatura.swift in Sources */,
+				84BFB652246C276800506ED1 /* NatElevation.swift in Sources */,
 				8427A2A82449F9AC00CF30D5 /* ContentColorPalette.swift in Sources */,
 				843FA27B2461D82200D20D9A /* NatSizes.swift in Sources */,
 				8427A2AE2449FE1200CF30D5 /* TheBodyShopTheme.swift in Sources */,
@@ -1594,14 +1623,17 @@
 				843FA29C2463369A00D20D9A /* TheBodyShopRadius.swift in Sources */,
 				643ABFF124118536000918EA /* FlatButton.swift in Sources */,
 				843FA2B82464736500D20D9A /* Opacities.swift in Sources */,
+				84BFB663246DA50100506ED1 /* TheBodyShopElevations.swift in Sources */,
 				843FA2962463310900D20D9A /* Radius.swift in Sources */,
 				8427A2A02449F2A700CF30D5 /* ColorPalette.swift in Sources */,
 				64DF47E323FB492100DAF441 /* TextFieldType.swift in Sources */,
 				8427A32C24538DFA00CF30D5 /* ConfigurationStorage.swift in Sources */,
 				8427A297244788D400CF30D5 /* TheBodyShopColorPaletteDark.swift in Sources */,
+				84BFB65F246DA47500506ED1 /* AvonElevations.swift in Sources */,
 				84BFB6382469BF4B00506ED1 /* AvonFontSizes.swift in Sources */,
 				43C02A3523FAFDDD0057A31C /* NSMutableAttributedString+Builder.swift in Sources */,
 				117FE024238D9B070032E2AC /* Colors.swift in Sources */,
+				84BFB65D246DA42800506ED1 /* ElevationAttributes.swift in Sources */,
 				A988199B238C5AAF0008230F /* UIColor+Hex.swift in Sources */,
 				8427A2CA2451D05700CF30D5 /* NaturaColorPaletteLight.swift in Sources */,
 				843FA29A246335D700D20D9A /* NaturaBorderRadius.swift in Sources */,

--- a/SampleApp/NatDS-SampleApp.xcodeproj/project.pbxproj
+++ b/SampleApp/NatDS-SampleApp.xcodeproj/project.pbxproj
@@ -26,6 +26,8 @@
 		846313B024603BC200387FCF /* SpacingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 846313AF24603BC200387FCF /* SpacingViewController.swift */; };
 		846313B424603E0100387FCF /* SpacingCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 846313B324603E0100387FCF /* SpacingCell.swift */; };
 		84BFB64E2469CE7E00506ED1 /* TypographyCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84BFB64D2469CE7E00506ED1 /* TypographyCell.swift */; };
+		84BFB655246D689000506ED1 /* ElevationViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84BFB654246D689000506ED1 /* ElevationViewController.swift */; };
+		84BFB658246D694700506ED1 /* ElevationCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84BFB657246D694700506ED1 /* ElevationCell.swift */; };
 		A904ECBA23D607D800709B43 /* ComponentsSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = A904ECB923D607D800709B43 /* ComponentsSection.swift */; };
 		A904ECBC23D6088600709B43 /* ButtonsItemViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A904ECBB23D6088600709B43 /* ButtonsItemViewController.swift */; };
 		A904ECC023D760C400709B43 /* DesignSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = A904ECBF23D760C400709B43 /* DesignSection.swift */; };
@@ -77,6 +79,8 @@
 		846313AF24603BC200387FCF /* SpacingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpacingViewController.swift; sourceTree = "<group>"; };
 		846313B324603E0100387FCF /* SpacingCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpacingCell.swift; sourceTree = "<group>"; };
 		84BFB64D2469CE7E00506ED1 /* TypographyCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TypographyCell.swift; sourceTree = "<group>"; };
+		84BFB654246D689000506ED1 /* ElevationViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ElevationViewController.swift; sourceTree = "<group>"; };
+		84BFB657246D694700506ED1 /* ElevationCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ElevationCell.swift; sourceTree = "<group>"; };
 		A904ECB923D607D800709B43 /* ComponentsSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComponentsSection.swift; sourceTree = "<group>"; };
 		A904ECBB23D6088600709B43 /* ButtonsItemViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ButtonsItemViewController.swift; sourceTree = "<group>"; };
 		A904ECBF23D760C400709B43 /* DesignSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DesignSection.swift; sourceTree = "<group>"; };
@@ -248,6 +252,23 @@
 			path = Cells;
 			sourceTree = "<group>";
 		};
+		84BFB653246CA6AA00506ED1 /* Elevation */ = {
+			isa = PBXGroup;
+			children = (
+				84BFB656246D691900506ED1 /* Cells */,
+				84BFB654246D689000506ED1 /* ElevationViewController.swift */,
+			);
+			path = Elevation;
+			sourceTree = "<group>";
+		};
+		84BFB656246D691900506ED1 /* Cells */ = {
+			isa = PBXGroup;
+			children = (
+				84BFB657246D694700506ED1 /* ElevationCell.swift */,
+			);
+			path = Cells;
+			sourceTree = "<group>";
+		};
 		A904ECB823D607BD00709B43 /* Button */ = {
 			isa = PBXGroup;
 			children = (
@@ -282,6 +303,7 @@
 				843FA2D62466491000D20D9A /* Tipography */,
 				843FA29F2463445C00D20D9A /* BorderRadius */,
 				843FA2C32464883200D20D9A /* Opacity */,
+				84BFB653246CA6AA00506ED1 /* Elevation */,
 			);
 			path = Design;
 			sourceTree = "<group>";
@@ -463,6 +485,7 @@
 				A904ECBA23D607D800709B43 /* ComponentsSection.swift in Sources */,
 				A97328BF23CFA32900ADC5C2 /* SampleSection.swift in Sources */,
 				843FA2A52463451B00D20D9A /* SizeCell.swift in Sources */,
+				84BFB655246D689000506ED1 /* ElevationViewController.swift in Sources */,
 				A904ECC023D760C400709B43 /* DesignSection.swift in Sources */,
 				A9D71BC22386DFEE00CDEC1D /* AppDelegate.swift in Sources */,
 				8427A3362458764900CF30D5 /* ColorsViewController.swift in Sources */,
@@ -471,6 +494,7 @@
 				843FA2A82463480100D20D9A /* BorderRadiusCell.swift in Sources */,
 				843FA2D52466478B00D20D9A /* TypographyViewController.swift in Sources */,
 				437CFD4F241059B8008CEA37 /* DividerViewController.swift in Sources */,
+				84BFB658246D694700506ED1 /* ElevationCell.swift in Sources */,
 				8427A3312457AFEF00CF30D5 /* ChooseBrandViewController.swift in Sources */,
 				A97328C323CFA35800ADC5C2 /* MainViewController.swift in Sources */,
 				A97328BD23CFA2F500ADC5C2 /* MainDataSource.swift in Sources */,

--- a/SampleApp/Sources/Sample/Design/DesignSection.swift
+++ b/SampleApp/Sources/Sample/Design/DesignSection.swift
@@ -5,6 +5,7 @@ class DesignSection: SampleSection {
     var items: [SampleItem.Type] = [
         BorderRadiusViewController.self,
         ColorsViewController.self,
+        ElevationViewController.self,
         SizeViewController.self,
         SpacingViewController.self,
         OpacityViewController.self,

--- a/SampleApp/Sources/Sample/Design/Elevation/Cells/ElevationCell.swift
+++ b/SampleApp/Sources/Sample/Design/Elevation/Cells/ElevationCell.swift
@@ -17,7 +17,7 @@ final class ElevationCell: UITableViewCell {
     private let symbolicView: UIView = {
         let view = UIView()
         view.backgroundColor = NatColors.surface
-//        view.layer.cornerRadius = NatBorderRadius.medium
+        view.layer.cornerRadius = NatBorderRadius.medium
         view.translatesAutoresizingMaskIntoConstraints = false
 
         return view
@@ -38,6 +38,15 @@ final class ElevationCell: UITableViewCell {
         fatalError("init(coder:) has not been implemented")
     }
 
+    // MARK: - Overrides
+
+    override func prepareForReuse() {
+        symbolicView.layer.shadowColor = nil
+        symbolicView.layer.shadowOffset = .zero
+        symbolicView.layer.shadowRadius = 3
+        symbolicView.layer.shadowOpacity = 0
+    }
+
     // MARK: - Public methods
 
     func configure(description: String, elevation: NatElevation.Elevation?) {
@@ -45,10 +54,8 @@ final class ElevationCell: UITableViewCell {
 
         if let elevation = elevation {
             NatElevation().apply(onView: symbolicView, elevation: elevation)
-            symbolicView.setNeedsLayout()
         }
     }
-
     // MARK: - Private methods
 
     private func setup() {

--- a/SampleApp/Sources/Sample/Design/Elevation/Cells/ElevationCell.swift
+++ b/SampleApp/Sources/Sample/Design/Elevation/Cells/ElevationCell.swift
@@ -1,0 +1,72 @@
+import UIKit
+import NatDS
+
+final class ElevationCell: UITableViewCell {
+
+    // MARK: - Private properties
+
+    private let label: UILabel = {
+        let label = UILabel()
+        label.font = NatFonts.font(ofSize: .body1, withWeight: .regular)
+        label.textColor = NatColors.mediumEmphasis
+        label.translatesAutoresizingMaskIntoConstraints = false
+
+        return label
+    }()
+
+    private let symbolicView: UIView = {
+        let view = UIView()
+        view.backgroundColor = NatColors.surface
+//        view.layer.cornerRadius = NatBorderRadius.medium
+        view.translatesAutoresizingMaskIntoConstraints = false
+
+        return view
+    }()
+
+    private var symbolicSizeWidthConstraint: NSLayoutConstraint!
+
+    // MARK: - Inits
+
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+
+        setup()
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - Public methods
+
+    func configure(description: String, elevation: NatElevation.Elevation?) {
+        label.text = description
+
+        if let elevation = elevation {
+            NatElevation().apply(onView: symbolicView, elevation: elevation)
+            symbolicView.setNeedsLayout()
+        }
+    }
+
+    // MARK: - Private methods
+
+    private func setup() {
+        contentView.backgroundColor = NatColors.background
+        contentView.addSubview(label)
+        contentView.addSubview(symbolicView)
+
+        NSLayoutConstraint.activate([
+            label.topAnchor.constraint(equalTo: contentView.topAnchor, constant: NatSpacing.micro),
+            label.leftAnchor.constraint(equalTo: contentView.leftAnchor),
+
+            symbolicView.topAnchor.constraint(
+                equalTo: label.bottomAnchor,
+                constant: NatSpacing.micro
+            ),
+            symbolicView.widthAnchor.constraint(equalToConstant: NatSizes.huge),
+            symbolicView.heightAnchor.constraint(equalToConstant: NatSizes.huge),
+            symbolicView.centerXAnchor.constraint(equalTo: contentView.centerXAnchor)
+        ])
+    }
+}

--- a/SampleApp/Sources/Sample/Design/Elevation/Cells/ElevationCell.swift
+++ b/SampleApp/Sources/Sample/Design/Elevation/Cells/ElevationCell.swift
@@ -53,7 +53,7 @@ final class ElevationCell: UITableViewCell {
         label.text = description
 
         if let elevation = elevation {
-            NatElevation().apply(onView: symbolicView, elevation: elevation)
+            NatElevation.apply(onView: symbolicView, elevation: elevation)
         }
     }
     // MARK: - Private methods

--- a/SampleApp/Sources/Sample/Design/Elevation/ElevationViewController.swift
+++ b/SampleApp/Sources/Sample/Design/Elevation/ElevationViewController.swift
@@ -1,0 +1,91 @@
+import UIKit
+import NatDS
+
+final class ElevationViewController: UIViewController, SampleItem {
+    static var name = "Elevation"
+
+    // MARK: - Private properties
+
+    private lazy var tableView: UITableView = {
+        let tableView = UITableView()
+        tableView.register(
+            ElevationCell.self,
+            forCellReuseIdentifier: ElevationCell.reuseIdentifier
+        )
+        tableView.rowHeight = NatSizes.hugeXX
+        tableView.allowsSelection = false
+        tableView.translatesAutoresizingMaskIntoConstraints = false
+        tableView.dataSource = self
+
+        return tableView
+    }()
+
+    private let cellsViewModels: [(description: String, value: NatElevation.Elevation?)] = [
+        ("elevation00", nil),
+        ("elevation01", .elevation01),
+        ("elevation02", .elevation02),
+        ("elevation03", .elevation03),
+        ("elevation04", .elevation04),
+        ("elevation05", .elevation05),
+        ("elevation06", .elevation06),
+        ("elevation07", .elevation07),
+        ("elevation08", .elevation08),
+        ("elevation09", .elevation09),
+        ("elevation10", .elevation10)
+    ]
+
+    // MARK: - Life cycle
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        title = Self.name
+
+        setup()
+    }
+
+    // MARK: - Private methods
+
+    private func setup() {
+        view.backgroundColor = NatColors.background
+        view.addSubview(tableView)
+
+        NSLayoutConstraint.activate([
+            tableView.topAnchor.constraint(
+                equalTo: view.safeAreaLayoutGuide.topAnchor
+            ),
+            tableView.rightAnchor.constraint(
+                equalTo: view.safeAreaLayoutGuide.rightAnchor,
+                constant: -NatSpacing.tiny
+            ),
+            tableView.bottomAnchor.constraint(
+                equalTo: view.safeAreaLayoutGuide.bottomAnchor
+            ),
+            tableView.leftAnchor.constraint(
+                equalTo: view.safeAreaLayoutGuide.leftAnchor,
+                constant: NatSpacing.tiny
+            )
+        ])
+    }
+}
+
+// MARK: - UITableViewDataSource
+
+extension ElevationViewController: UITableViewDataSource {
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        cellsViewModels.count
+    }
+
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let cell = tableView.dequeueReusableCell(
+            withIdentifier: ElevationCell.reuseIdentifier,
+            for: indexPath
+        ) as? ElevationCell ?? ElevationCell()
+
+        let viewModel = cellsViewModels[indexPath.row]
+
+        cell.configure(description: viewModel.description, elevation: viewModel.value)
+
+        return cell
+    }
+}

--- a/SampleApp/Sources/Sample/Design/Elevation/ElevationViewController.swift
+++ b/SampleApp/Sources/Sample/Design/Elevation/ElevationViewController.swift
@@ -21,7 +21,7 @@ final class ElevationViewController: UIViewController, SampleItem {
     }()
 
     private let cellsViewModels: [(description: String, value: NatElevation.Elevation?)] = [
-        ("elevation00", nil),
+        ("none", nil),
         ("elevation01", .elevation01),
         ("elevation02", .elevation02),
         ("elevation03", .elevation03),

--- a/Sources/Core/DesignTokens/Elevation/ElevationAttributes.swift
+++ b/Sources/Core/DesignTokens/Elevation/ElevationAttributes.swift
@@ -1,0 +1,6 @@
+struct ElevationAttributes {
+    let shadowColor: CGColor
+    let shadowOffSet: CGSize
+    let shadowRadius: CGFloat
+    let shadowOpacity: Float
+}

--- a/Sources/Core/DesignTokens/Elevation/Elevations.swift
+++ b/Sources/Core/DesignTokens/Elevation/Elevations.swift
@@ -1,0 +1,12 @@
+protocol Elevations {
+    var elevation01: ElevationAttributes { get }
+    var elevation02: ElevationAttributes { get }
+    var elevation03: ElevationAttributes { get }
+    var elevation04: ElevationAttributes { get }
+    var elevation05: ElevationAttributes { get }
+    var elevation06: ElevationAttributes { get }
+    var elevation07: ElevationAttributes { get }
+    var elevation08: ElevationAttributes { get }
+    var elevation09: ElevationAttributes { get }
+    var elevation10: ElevationAttributes { get }
+}

--- a/Sources/Core/Theme/SupportedBrands/Avon/AvonElevations.swift
+++ b/Sources/Core/Theme/SupportedBrands/Avon/AvonElevations.swift
@@ -1,0 +1,71 @@
+final class AvonElevations: Elevations {
+    lazy var elevation01: ElevationAttributes = .init(
+        shadowColor: UIColor(red: 0, green: 0, blue: 0, alpha: 1).cgColor,
+        shadowOffSet: .init(width: 0, height: 1),
+        shadowRadius: 1,
+        shadowOpacity: 0.14
+    )
+
+    lazy var elevation02: ElevationAttributes = .init(
+        shadowColor: UIColor(red: 0, green: 0, blue: 0, alpha: 1).cgColor,
+        shadowOffSet: .init(width: 0, height: 2),
+        shadowRadius: 2,
+        shadowOpacity: 0.14
+    )
+
+    lazy var elevation03: ElevationAttributes = .init(
+        shadowColor: UIColor(red: 0, green: 0, blue: 0, alpha: 1).cgColor,
+        shadowOffSet: .init(width: 0, height: 3),
+        shadowRadius: 4,
+        shadowOpacity: 0.14
+    )
+
+    lazy var elevation04: ElevationAttributes = .init(
+        shadowColor: UIColor(red: 0, green: 0, blue: 0, alpha: 1).cgColor,
+        shadowOffSet: .init(width: 0, height: 4),
+        shadowRadius: 5,
+        shadowOpacity: 0.14
+    )
+
+    lazy var elevation05: ElevationAttributes = .init(
+        shadowColor: UIColor(red: 0, green: 0, blue: 0, alpha: 1).cgColor,
+        shadowOffSet: .init(width: 0, height: 6),
+        shadowRadius: 10,
+        shadowOpacity: 0.14
+    )
+
+    lazy var elevation06: ElevationAttributes = .init(
+        shadowColor: UIColor(red: 0, green: 0, blue: 0, alpha: 1).cgColor,
+        shadowOffSet: .init(width: 0, height: 8),
+        shadowRadius: 10,
+        shadowOpacity: 0.14
+    )
+
+    lazy var elevation07: ElevationAttributes = .init(
+        shadowColor: UIColor(red: 0, green: 0, blue: 0, alpha: 1).cgColor,
+        shadowOffSet: .init(width: 0, height: 9),
+        shadowRadius: 12,
+        shadowOpacity: 0.14
+    )
+
+    lazy var elevation08: ElevationAttributes = .init(
+        shadowColor: UIColor(red: 0, green: 0, blue: 0, alpha: 1).cgColor,
+        shadowOffSet: .init(width: 0, height: 12),
+        shadowRadius: 17,
+        shadowOpacity: 0.14
+    )
+
+    lazy var elevation09: ElevationAttributes = .init(
+        shadowColor: UIColor(red: 0, green: 0, blue: 0, alpha: 1).cgColor,
+        shadowOffSet: .init(width: 0, height: 16),
+        shadowRadius: 24,
+        shadowOpacity: 0.14
+    )
+
+    lazy var elevation10: ElevationAttributes = .init(
+        shadowColor: UIColor(red: 0, green: 0, blue: 0, alpha: 1).cgColor,
+        shadowOffSet: .init(width: 0, height: 24),
+        shadowRadius: 38,
+        shadowOpacity: 0.14
+    )
+}

--- a/Sources/Core/Theme/SupportedBrands/Avon/AvonTheme.swift
+++ b/Sources/Core/Theme/SupportedBrands/Avon/AvonTheme.swift
@@ -6,4 +6,5 @@ struct AvonTheme: Theme {
     let borderRadius: BorderRadius = AvonBorderRadius()
     let opacities: Opacities = AvonOpacities()
     let font: Font = AvonFont()
+    let elevations: Elevations = AvonElevations()
 }

--- a/Sources/Core/Theme/SupportedBrands/Natura/NaturaElevations.swift
+++ b/Sources/Core/Theme/SupportedBrands/Natura/NaturaElevations.swift
@@ -1,0 +1,71 @@
+final class NaturaElevations: Elevations {
+    lazy var elevation01: ElevationAttributes = .init(
+        shadowColor: UIColor(red: 0, green: 0, blue: 0, alpha: 1).cgColor,
+        shadowOffSet: .init(width: 0, height: 1),
+        shadowRadius: 1,
+        shadowOpacity: 0.14
+    )
+
+    lazy var elevation02: ElevationAttributes = .init(
+        shadowColor: UIColor(red: 0, green: 0, blue: 0, alpha: 1).cgColor,
+        shadowOffSet: .init(width: 0, height: 2),
+        shadowRadius: 2,
+        shadowOpacity: 0.14
+    )
+
+    lazy var elevation03: ElevationAttributes = .init(
+        shadowColor: UIColor(red: 0, green: 0, blue: 0, alpha: 1).cgColor,
+        shadowOffSet: .init(width: 0, height: 3),
+        shadowRadius: 4,
+        shadowOpacity: 0.14
+    )
+
+    lazy var elevation04: ElevationAttributes = .init(
+        shadowColor: UIColor(red: 0, green: 0, blue: 0, alpha: 1).cgColor,
+        shadowOffSet: .init(width: 0, height: 4),
+        shadowRadius: 5,
+        shadowOpacity: 0.14
+    )
+
+    lazy var elevation05: ElevationAttributes = .init(
+        shadowColor: UIColor(red: 0, green: 0, blue: 0, alpha: 1).cgColor,
+        shadowOffSet: .init(width: 0, height: 6),
+        shadowRadius: 10,
+        shadowOpacity: 0.14
+    )
+
+    lazy var elevation06: ElevationAttributes = .init(
+        shadowColor: UIColor(red: 0, green: 0, blue: 0, alpha: 1).cgColor,
+        shadowOffSet: .init(width: 0, height: 8),
+        shadowRadius: 10,
+        shadowOpacity: 0.14
+    )
+
+    lazy var elevation07: ElevationAttributes = .init(
+        shadowColor: UIColor(red: 0, green: 0, blue: 0, alpha: 1).cgColor,
+        shadowOffSet: .init(width: 0, height: 9),
+        shadowRadius: 12,
+        shadowOpacity: 0.14
+    )
+
+    lazy var elevation08: ElevationAttributes = .init(
+        shadowColor: UIColor(red: 0, green: 0, blue: 0, alpha: 1).cgColor,
+        shadowOffSet: .init(width: 0, height: 12),
+        shadowRadius: 17,
+        shadowOpacity: 0.14
+    )
+
+    lazy var elevation09: ElevationAttributes = .init(
+        shadowColor: UIColor(red: 0, green: 0, blue: 0, alpha: 1).cgColor,
+        shadowOffSet: .init(width: 0, height: 16),
+        shadowRadius: 24,
+        shadowOpacity: 0.14
+    )
+
+    lazy var elevation10: ElevationAttributes = .init(
+        shadowColor: UIColor(red: 0, green: 0, blue: 0, alpha: 1).cgColor,
+        shadowOffSet: .init(width: 0, height: 24),
+        shadowRadius: 38,
+        shadowOpacity: 0.14
+    )
+}

--- a/Sources/Core/Theme/SupportedBrands/Natura/NaturaTheme.swift
+++ b/Sources/Core/Theme/SupportedBrands/Natura/NaturaTheme.swift
@@ -6,4 +6,5 @@ struct NaturaTheme: Theme {
     let borderRadius: BorderRadius = NaturaBorderRadius()
     let opacities: Opacities = NaturaOpacities()
     let font: Font = NaturaFont()
+    let elevations: Elevations = NaturaElevations()
 }

--- a/Sources/Core/Theme/SupportedBrands/TheBodyShop/TheBodyShopElevations.swift
+++ b/Sources/Core/Theme/SupportedBrands/TheBodyShop/TheBodyShopElevations.swift
@@ -1,0 +1,71 @@
+final class TheBodyShopElevations: Elevations {
+    lazy var elevation01: ElevationAttributes = .init(
+        shadowColor: UIColor(red: 0, green: 0, blue: 0, alpha: 1).cgColor,
+        shadowOffSet: .init(width: 0, height: 1),
+        shadowRadius: 1,
+        shadowOpacity: 0.14
+    )
+
+    lazy var elevation02: ElevationAttributes = .init(
+        shadowColor: UIColor(red: 0, green: 0, blue: 0, alpha: 1).cgColor,
+        shadowOffSet: .init(width: 0, height: 2),
+        shadowRadius: 2,
+        shadowOpacity: 0.14
+    )
+
+    lazy var elevation03: ElevationAttributes = .init(
+        shadowColor: UIColor(red: 0, green: 0, blue: 0, alpha: 1).cgColor,
+        shadowOffSet: .init(width: 0, height: 3),
+        shadowRadius: 4,
+        shadowOpacity: 0.14
+    )
+
+    lazy var elevation04: ElevationAttributes = .init(
+        shadowColor: UIColor(red: 0, green: 0, blue: 0, alpha: 1).cgColor,
+        shadowOffSet: .init(width: 0, height: 4),
+        shadowRadius: 5,
+        shadowOpacity: 0.14
+    )
+
+    lazy var elevation05: ElevationAttributes = .init(
+        shadowColor: UIColor(red: 0, green: 0, blue: 0, alpha: 1).cgColor,
+        shadowOffSet: .init(width: 0, height: 6),
+        shadowRadius: 10,
+        shadowOpacity: 0.14
+    )
+
+    lazy var elevation06: ElevationAttributes = .init(
+        shadowColor: UIColor(red: 0, green: 0, blue: 0, alpha: 1).cgColor,
+        shadowOffSet: .init(width: 0, height: 8),
+        shadowRadius: 10,
+        shadowOpacity: 0.14
+    )
+
+    lazy var elevation07: ElevationAttributes = .init(
+        shadowColor: UIColor(red: 0, green: 0, blue: 0, alpha: 1).cgColor,
+        shadowOffSet: .init(width: 0, height: 9),
+        shadowRadius: 12,
+        shadowOpacity: 0.14
+    )
+
+    lazy var elevation08: ElevationAttributes = .init(
+        shadowColor: UIColor(red: 0, green: 0, blue: 0, alpha: 1).cgColor,
+        shadowOffSet: .init(width: 0, height: 12),
+        shadowRadius: 17,
+        shadowOpacity: 0.14
+    )
+
+    lazy var elevation09: ElevationAttributes = .init(
+        shadowColor: UIColor(red: 0, green: 0, blue: 0, alpha: 1).cgColor,
+        shadowOffSet: .init(width: 0, height: 16),
+        shadowRadius: 24,
+        shadowOpacity: 0.14
+    )
+
+    lazy var elevation10: ElevationAttributes = .init(
+        shadowColor: UIColor(red: 0, green: 0, blue: 0, alpha: 1).cgColor,
+        shadowOffSet: .init(width: 0, height: 24),
+        shadowRadius: 38,
+        shadowOpacity: 0.14
+    )
+}

--- a/Sources/Core/Theme/SupportedBrands/TheBodyShop/TheBodyShopTheme.swift
+++ b/Sources/Core/Theme/SupportedBrands/TheBodyShop/TheBodyShopTheme.swift
@@ -6,4 +6,5 @@ struct TheBodyShopTheme: Theme {
     let borderRadius: BorderRadius = TheBodyShopBorderRadius()
     let opacities: Opacities = TheBodyShopOpacities()
     let font: Font = TheBodyShopFont()
+    let elevations: Elevations = TheBodyShopElevations()
 }

--- a/Sources/Core/Theme/Theme.swift
+++ b/Sources/Core/Theme/Theme.swift
@@ -8,4 +8,5 @@ protocol Theme {
     var borderRadius: BorderRadius { get }
     var opacities: Opacities { get }
     var font: Font { get }
+    var elevations: Elevations { get }
 }

--- a/Sources/Core/ViewStyling/ViewStyling.swift
+++ b/Sources/Core/ViewStyling/ViewStyling.swift
@@ -1,0 +1,9 @@
+struct ViewStyling {
+    func setElevation(onView view: UIView, with attributtes: ElevationAttributes) {
+        view.layer.shadowColor = attributtes.shadowColor
+        view.layer.shadowOffset = attributtes.shadowOffSet
+        view.layer.shadowRadius = attributtes.shadowRadius
+        view.layer.shadowOpacity = attributtes.shadowOpacity
+        view.layer.masksToBounds = false
+    }
+}

--- a/Sources/Core/ViewStyling/ViewStyling.swift
+++ b/Sources/Core/ViewStyling/ViewStyling.swift
@@ -1,5 +1,5 @@
-struct ViewStyling {
-    func applyElevation(onView view: UIView, with attributtes: ElevationAttributes) {
+enum ViewStyling {
+    static func applyElevation(onView view: UIView, with attributtes: ElevationAttributes) {
         view.layer.shadowColor = attributtes.shadowColor
         view.layer.shadowOffset = attributtes.shadowOffSet
         view.layer.shadowRadius = attributtes.shadowRadius

--- a/Sources/Core/ViewStyling/ViewStyling.swift
+++ b/Sources/Core/ViewStyling/ViewStyling.swift
@@ -1,5 +1,5 @@
 struct ViewStyling {
-    func setElevation(onView view: UIView, with attributtes: ElevationAttributes) {
+    func applyElevation(onView view: UIView, with attributtes: ElevationAttributes) {
         view.layer.shadowColor = attributtes.shadowColor
         view.layer.shadowOffset = attributtes.shadowOffSet
         view.layer.shadowRadius = attributtes.shadowRadius

--- a/Sources/Public/DesignTokens/NatColors.swift
+++ b/Sources/Public/DesignTokens/NatColors.swift
@@ -15,9 +15,9 @@
     - Surface:
         background, onBackground, surface, onSurface
     - Content:
-        highlight, highEmphasis, mediumEmphasis, lowEmphasis, link, onLink
+        highlight, highEmphasis, mediumEmphasis, lowEmphasis
     - Feedback:
-        success, onSuccess, warning, onWarning, alert, onAlert
+        success, onSuccess, warning, onWarning, alert, onAlert, link, onLink
 
     Exemple of usage:
 

--- a/Sources/Public/DesignTokens/NatElevation.swift
+++ b/Sources/Public/DesignTokens/NatElevation.swift
@@ -1,0 +1,9 @@
+//
+//  NatElevation.swift
+//  NatDS
+//
+//  Created by Raoni Valadares on 13/05/20.
+//  Copyright © 2020 Natura. All rights reserved.
+//
+
+import Foundation

--- a/Sources/Public/DesignTokens/NatElevation.swift
+++ b/Sources/Public/DesignTokens/NatElevation.swift
@@ -1,9 +1,53 @@
-//
-//  NatElevation.swift
-//  NatDS
-//
-//  Created by Raoni Valadares on 13/05/20.
-//  Copyright © 2020 Natura. All rights reserved.
-//
+public final class NatElevation {
+    public init() {}
 
-import Foundation
+    public func apply(onView view: UIView, elevation: Elevation) {
+        let elevation = getTheme().elevations[keyPath: elevation.rawValue]
+        ViewStyling().setElevation(onView: view, with: elevation)
+    }
+}
+
+extension NatElevation {
+    public enum Elevation {
+        case elevation01
+        case elevation02
+        case elevation03
+        case elevation04
+        case elevation05
+        case elevation06
+        case elevation07
+        case elevation08
+        case elevation09
+        case elevation10
+
+        var rawValue: KeyPath<Elevations, ElevationAttributes> {
+            let keyPath: KeyPath<Elevations, ElevationAttributes>
+
+            switch self {
+            case .elevation01: keyPath = \.elevation01
+            case .elevation02: keyPath = \.elevation02
+            case .elevation03: keyPath = \.elevation03
+            case .elevation04: keyPath = \.elevation04
+            case .elevation05: keyPath = \.elevation05
+            case .elevation06: keyPath = \.elevation06
+            case .elevation07: keyPath = \.elevation07
+            case .elevation08: keyPath = \.elevation08
+            case .elevation09: keyPath = \.elevation09
+            case .elevation10: keyPath = \.elevation10
+            }
+
+            return keyPath
+        }
+    }
+}
+
+struct ViewStyling {
+    func setElevation(onView view: UIView, with attributtes: ElevationAttributes) {
+        print(attributtes)
+        view.layer.shadowColor = attributtes.shadowColor
+        view.layer.shadowOffset = attributtes.shadowOffSet
+        view.layer.shadowRadius = attributtes.shadowRadius
+        view.layer.shadowOpacity = attributtes.shadowOpacity
+        view.layer.masksToBounds = false
+    }
+}

--- a/Sources/Public/DesignTokens/NatElevation.swift
+++ b/Sources/Public/DesignTokens/NatElevation.swift
@@ -2,8 +2,8 @@ public final class NatElevation {
     public init() {}
 
     public func apply(onView view: UIView, elevation: Elevation) {
-        let elevation = getTheme().elevations[keyPath: elevation.rawValue]
-        ViewStyling().setElevation(onView: view, with: elevation)
+        let attributes = getTheme().elevations[keyPath: elevation.rawValue]
+        ViewStyling().applyElevation(onView: view, with: attributes)
     }
 }
 

--- a/Sources/Public/DesignTokens/NatElevation.swift
+++ b/Sources/Public/DesignTokens/NatElevation.swift
@@ -1,8 +1,23 @@
-public final class NatElevation {
-    public init() {}
+/**
+  NatElevation is a struct that has access to elevation attributes properties from the Design System.
+  This properties are used with view.layer to create elevation visual effect.
+  According with the current Brand in the Design System this properties can change.
 
-    public func apply(onView view: UIView, elevation: Elevation) {
+    Exemple of usage:
+
+        NatElevation.apply(onView: variantCardView, with: elevation09)
+
+ - Requires:
+        It's necessary to configure the Design System current Brand at DesisgnSystem class
+        or fatalError will be raised.
+
+            DesignSystem().configure(with: Brand)
+*/
+
+public struct NatElevation {
+    public static func apply(onView view: UIView, elevation: Elevation) {
         let attributes = getTheme().elevations[keyPath: elevation.rawValue]
+
         ViewStyling().applyElevation(onView: view, with: attributes)
     }
 }

--- a/Sources/Public/DesignTokens/NatElevation.swift
+++ b/Sources/Public/DesignTokens/NatElevation.swift
@@ -18,7 +18,7 @@ public struct NatElevation {
     public static func apply(onView view: UIView, elevation: Elevation) {
         let attributes = getTheme().elevations[keyPath: elevation.rawValue]
 
-        ViewStyling().applyElevation(onView: view, with: attributes)
+        ViewStyling.applyElevation(onView: view, with: attributes)
     }
 }
 

--- a/Sources/Public/DesignTokens/NatElevation.swift
+++ b/Sources/Public/DesignTokens/NatElevation.swift
@@ -40,14 +40,3 @@ extension NatElevation {
         }
     }
 }
-
-struct ViewStyling {
-    func setElevation(onView view: UIView, with attributtes: ElevationAttributes) {
-        print(attributtes)
-        view.layer.shadowColor = attributtes.shadowColor
-        view.layer.shadowOffset = attributtes.shadowOffSet
-        view.layer.shadowRadius = attributtes.shadowRadius
-        view.layer.shadowOpacity = attributtes.shadowOpacity
-        view.layer.masksToBounds = false
-    }
-}

--- a/Tests/Core/SupportedBrands/Avon/AvonElevations+Spec.swift
+++ b/Tests/Core/SupportedBrands/Avon/AvonElevations+Spec.swift
@@ -6,7 +6,6 @@ import Nimble
 final class AvonElevationsSpec: QuickSpec {
     override func spec() {
         let systemUnderTest = AvonElevations()
-        var view: UIView!
 
         describe("#elevation01") {
             let attributes = systemUnderTest.elevation01

--- a/Tests/Core/SupportedBrands/Avon/AvonElevations+Spec.swift
+++ b/Tests/Core/SupportedBrands/Avon/AvonElevations+Spec.swift
@@ -1,0 +1,220 @@
+import Quick
+import Nimble
+
+@testable import NatDS
+
+final class AvonElevationsSpec: QuickSpec {
+    override func spec() {
+        let systemUnderTest = AvonElevations()
+
+        describe("#elevation01") {
+            let attributes = systemUnderTest.elevation01
+
+            it("returns a expect shadowColor") {
+                let cgColor = UIColor(red: 0, green: 0, blue: 0, alpha: 1).cgColor
+                expect(attributes.shadowColor).to(equal(cgColor))
+            }
+
+            it("returns a expect shadowOffSet") {
+                expect(attributes.shadowOffSet).to(equal(.init(width: 0, height: 1)))
+            }
+
+            it("returns a expect shadowRadius") {
+                expect(attributes.shadowRadius).to(equal(1))
+            }
+
+            it("returns a expect shadowOpacity") {
+                expect(attributes.shadowOpacity).to(equal(0.14))
+            }
+        }
+
+        describe("#elevation02") {
+            let attributes = systemUnderTest.elevation02
+
+            it("returns a expect shadowColor") {
+                let cgColor = UIColor(red: 0, green: 0, blue: 0, alpha: 1).cgColor
+                expect(attributes.shadowColor).to(equal(cgColor))
+            }
+
+            it("returns a expect shadowOffSet") {
+                expect(attributes.shadowOffSet).to(equal(.init(width: 0, height: 2)))
+            }
+
+            it("returns a expect shadowRadius") {
+                expect(attributes.shadowRadius).to(equal(2))
+            }
+
+            it("returns a expect shadowOpacity") {
+                expect(attributes.shadowOpacity).to(equal(0.14))
+            }
+        }
+
+        describe("#elevation03") {
+            let attributes = systemUnderTest.elevation03
+
+            it("returns a expect shadowColor") {
+                let cgColor = UIColor(red: 0, green: 0, blue: 0, alpha: 1).cgColor
+                expect(attributes.shadowColor).to(equal(cgColor))
+            }
+
+            it("returns a expect shadowOffSet") {
+                expect(attributes.shadowOffSet).to(equal(.init(width: 0, height: 3)))
+            }
+
+            it("returns a expect shadowRadius") {
+                expect(attributes.shadowRadius).to(equal(4))
+            }
+
+            it("returns a expect shadowOpacity") {
+                expect(attributes.shadowOpacity).to(equal(0.14))
+            }
+        }
+
+        describe("#elevation04") {
+            let attributes = systemUnderTest.elevation04
+
+            it("returns a expect shadowColor") {
+                let cgColor = UIColor(red: 0, green: 0, blue: 0, alpha: 1).cgColor
+                expect(attributes.shadowColor).to(equal(cgColor))
+            }
+
+            it("returns a expect shadowOffSet") {
+                expect(attributes.shadowOffSet).to(equal(.init(width: 0, height: 4)))
+            }
+
+            it("returns a expect shadowRadius") {
+                expect(attributes.shadowRadius).to(equal(5))
+            }
+
+            it("returns a expect shadowOpacity") {
+                expect(attributes.shadowOpacity).to(equal(0.14))
+            }
+        }
+
+        describe("#elevation05") {
+            let attributes = systemUnderTest.elevation05
+
+            it("returns a expect shadowColor") {
+                let cgColor = UIColor(red: 0, green: 0, blue: 0, alpha: 1).cgColor
+                expect(attributes.shadowColor).to(equal(cgColor))
+            }
+
+            it("returns a expect shadowOffSet") {
+                expect(attributes.shadowOffSet).to(equal(.init(width: 0, height: 6)))
+            }
+
+            it("returns a expect shadowRadius") {
+                expect(attributes.shadowRadius).to(equal(10))
+            }
+
+            it("returns a expect shadowOpacity") {
+                expect(attributes.shadowOpacity).to(equal(0.14))
+            }
+        }
+
+        describe("#elevation06") {
+            let attributes = systemUnderTest.elevation06
+
+            it("returns a expect shadowColor") {
+                let cgColor = UIColor(red: 0, green: 0, blue: 0, alpha: 1).cgColor
+                expect(attributes.shadowColor).to(equal(cgColor))
+            }
+
+            it("returns a expect shadowOffSet") {
+                expect(attributes.shadowOffSet).to(equal(.init(width: 0, height: 8)))
+            }
+
+            it("returns a expect shadowRadius") {
+                expect(attributes.shadowRadius).to(equal(10))
+            }
+
+            it("returns a expect shadowOpacity") {
+                expect(attributes.shadowOpacity).to(equal(0.14))
+            }
+        }
+
+        describe("#elevation07") {
+            let attributes = systemUnderTest.elevation07
+
+            it("returns a expect shadowColor") {
+                let cgColor = UIColor(red: 0, green: 0, blue: 0, alpha: 1).cgColor
+                expect(attributes.shadowColor).to(equal(cgColor))
+            }
+
+            it("returns a expect shadowOffSet") {
+                expect(attributes.shadowOffSet).to(equal(.init(width: 0, height: 9)))
+            }
+
+            it("returns a expect shadowRadius") {
+                expect(attributes.shadowRadius).to(equal(12))
+            }
+
+            it("returns a expect shadowOpacity") {
+                expect(attributes.shadowOpacity).to(equal(0.14))
+            }
+        }
+
+        describe("#elevation08") {
+            let attributes = systemUnderTest.elevation08
+
+            it("returns a expect shadowColor") {
+                let cgColor = UIColor(red: 0, green: 0, blue: 0, alpha: 1).cgColor
+                expect(attributes.shadowColor).to(equal(cgColor))
+            }
+
+            it("returns a expect shadowOffSet") {
+                expect(attributes.shadowOffSet).to(equal(.init(width: 0, height: 12)))
+            }
+
+            it("returns a expect shadowRadius") {
+                expect(attributes.shadowRadius).to(equal(17))
+            }
+
+            it("returns a expect shadowOpacity") {
+                expect(attributes.shadowOpacity).to(equal(0.14))
+            }
+        }
+
+        describe("#elevation09") {
+            let attributes = systemUnderTest.elevation09
+
+            it("returns a expect shadowColor") {
+                let cgColor = UIColor(red: 0, green: 0, blue: 0, alpha: 1).cgColor
+                expect(attributes.shadowColor).to(equal(cgColor))
+            }
+
+            it("returns a expect shadowOffSet") {
+                expect(attributes.shadowOffSet).to(equal(.init(width: 0, height: 16)))
+            }
+
+            it("returns a expect shadowRadius") {
+                expect(attributes.shadowRadius).to(equal(24))
+            }
+
+            it("returns a expect shadowOpacity") {
+                expect(attributes.shadowOpacity).to(equal(0.14))
+            }
+        }
+
+        describe("#elevation10") {
+            let attributes = systemUnderTest.elevation10
+
+            it("returns a expect shadowColor") {
+                let cgColor = UIColor(red: 0, green: 0, blue: 0, alpha: 1).cgColor
+                expect(attributes.shadowColor).to(equal(cgColor))
+            }
+
+            it("returns a expect shadowOffSet") {
+                expect(attributes.shadowOffSet).to(equal(.init(width: 0, height: 24)))
+            }
+
+            it("returns a expect shadowRadius") {
+                expect(attributes.shadowRadius).to(equal(38))
+            }
+
+            it("returns a expect shadowOpacity") {
+                expect(attributes.shadowOpacity).to(equal(0.14))
+            }
+        }
+    }
+}

--- a/Tests/Core/SupportedBrands/Avon/AvonElevations+Spec.swift
+++ b/Tests/Core/SupportedBrands/Avon/AvonElevations+Spec.swift
@@ -6,6 +6,7 @@ import Nimble
 final class AvonElevationsSpec: QuickSpec {
     override func spec() {
         let systemUnderTest = AvonElevations()
+        var view: UIView!
 
         describe("#elevation01") {
             let attributes = systemUnderTest.elevation01

--- a/Tests/Core/SupportedBrands/Avon/AvonThemeSpec.swift
+++ b/Tests/Core/SupportedBrands/Avon/AvonThemeSpec.swift
@@ -62,5 +62,13 @@ final class AvonThemeSpec: QuickSpec {
                 expect(font).to(beAnInstanceOf(AvonFont.self))
             }
         }
+
+        describe("#elevations") {
+            it("returns a instance of AvonElevations") {
+                let elevations = systemUnderTest.elevations
+
+                expect(elevations).to(beAnInstanceOf(AvonElevations.self))
+            }
+        }
     }
 }

--- a/Tests/Core/SupportedBrands/Natura/NaturaElevations+Spec.swift
+++ b/Tests/Core/SupportedBrands/Natura/NaturaElevations+Spec.swift
@@ -1,0 +1,220 @@
+import Quick
+import Nimble
+
+@testable import NatDS
+
+final class NaturaElevationsSpec: QuickSpec {
+    override func spec() {
+        let systemUnderTest = NaturaElevations()
+
+        describe("#elevation01") {
+            let attributes = systemUnderTest.elevation01
+
+            it("returns a expect shadowColor") {
+                let cgColor = UIColor(red: 0, green: 0, blue: 0, alpha: 1).cgColor
+                expect(attributes.shadowColor).to(equal(cgColor))
+            }
+
+            it("returns a expect shadowOffSet") {
+                expect(attributes.shadowOffSet).to(equal(.init(width: 0, height: 1)))
+            }
+
+            it("returns a expect shadowRadius") {
+                expect(attributes.shadowRadius).to(equal(1))
+            }
+
+            it("returns a expect shadowOpacity") {
+                expect(attributes.shadowOpacity).to(equal(0.14))
+            }
+        }
+
+        describe("#elevation02") {
+            let attributes = systemUnderTest.elevation02
+
+            it("returns a expect shadowColor") {
+                let cgColor = UIColor(red: 0, green: 0, blue: 0, alpha: 1).cgColor
+                expect(attributes.shadowColor).to(equal(cgColor))
+            }
+
+            it("returns a expect shadowOffSet") {
+                expect(attributes.shadowOffSet).to(equal(.init(width: 0, height: 2)))
+            }
+
+            it("returns a expect shadowRadius") {
+                expect(attributes.shadowRadius).to(equal(2))
+            }
+
+            it("returns a expect shadowOpacity") {
+                expect(attributes.shadowOpacity).to(equal(0.14))
+            }
+        }
+
+        describe("#elevation03") {
+            let attributes = systemUnderTest.elevation03
+
+            it("returns a expect shadowColor") {
+                let cgColor = UIColor(red: 0, green: 0, blue: 0, alpha: 1).cgColor
+                expect(attributes.shadowColor).to(equal(cgColor))
+            }
+
+            it("returns a expect shadowOffSet") {
+                expect(attributes.shadowOffSet).to(equal(.init(width: 0, height: 3)))
+            }
+
+            it("returns a expect shadowRadius") {
+                expect(attributes.shadowRadius).to(equal(4))
+            }
+
+            it("returns a expect shadowOpacity") {
+                expect(attributes.shadowOpacity).to(equal(0.14))
+            }
+        }
+
+        describe("#elevation04") {
+            let attributes = systemUnderTest.elevation04
+
+            it("returns a expect shadowColor") {
+                let cgColor = UIColor(red: 0, green: 0, blue: 0, alpha: 1).cgColor
+                expect(attributes.shadowColor).to(equal(cgColor))
+            }
+
+            it("returns a expect shadowOffSet") {
+                expect(attributes.shadowOffSet).to(equal(.init(width: 0, height: 4)))
+            }
+
+            it("returns a expect shadowRadius") {
+                expect(attributes.shadowRadius).to(equal(5))
+            }
+
+            it("returns a expect shadowOpacity") {
+                expect(attributes.shadowOpacity).to(equal(0.14))
+            }
+        }
+
+        describe("#elevation05") {
+            let attributes = systemUnderTest.elevation05
+
+            it("returns a expect shadowColor") {
+                let cgColor = UIColor(red: 0, green: 0, blue: 0, alpha: 1).cgColor
+                expect(attributes.shadowColor).to(equal(cgColor))
+            }
+
+            it("returns a expect shadowOffSet") {
+                expect(attributes.shadowOffSet).to(equal(.init(width: 0, height: 6)))
+            }
+
+            it("returns a expect shadowRadius") {
+                expect(attributes.shadowRadius).to(equal(10))
+            }
+
+            it("returns a expect shadowOpacity") {
+                expect(attributes.shadowOpacity).to(equal(0.14))
+            }
+        }
+
+        describe("#elevation06") {
+            let attributes = systemUnderTest.elevation06
+
+            it("returns a expect shadowColor") {
+                let cgColor = UIColor(red: 0, green: 0, blue: 0, alpha: 1).cgColor
+                expect(attributes.shadowColor).to(equal(cgColor))
+            }
+
+            it("returns a expect shadowOffSet") {
+                expect(attributes.shadowOffSet).to(equal(.init(width: 0, height: 8)))
+            }
+
+            it("returns a expect shadowRadius") {
+                expect(attributes.shadowRadius).to(equal(10))
+            }
+
+            it("returns a expect shadowOpacity") {
+                expect(attributes.shadowOpacity).to(equal(0.14))
+            }
+        }
+
+        describe("#elevation07") {
+            let attributes = systemUnderTest.elevation07
+
+            it("returns a expect shadowColor") {
+                let cgColor = UIColor(red: 0, green: 0, blue: 0, alpha: 1).cgColor
+                expect(attributes.shadowColor).to(equal(cgColor))
+            }
+
+            it("returns a expect shadowOffSet") {
+                expect(attributes.shadowOffSet).to(equal(.init(width: 0, height: 9)))
+            }
+
+            it("returns a expect shadowRadius") {
+                expect(attributes.shadowRadius).to(equal(12))
+            }
+
+            it("returns a expect shadowOpacity") {
+                expect(attributes.shadowOpacity).to(equal(0.14))
+            }
+        }
+
+        describe("#elevation08") {
+            let attributes = systemUnderTest.elevation08
+
+            it("returns a expect shadowColor") {
+                let cgColor = UIColor(red: 0, green: 0, blue: 0, alpha: 1).cgColor
+                expect(attributes.shadowColor).to(equal(cgColor))
+            }
+
+            it("returns a expect shadowOffSet") {
+                expect(attributes.shadowOffSet).to(equal(.init(width: 0, height: 12)))
+            }
+
+            it("returns a expect shadowRadius") {
+                expect(attributes.shadowRadius).to(equal(17))
+            }
+
+            it("returns a expect shadowOpacity") {
+                expect(attributes.shadowOpacity).to(equal(0.14))
+            }
+        }
+
+        describe("#elevation09") {
+            let attributes = systemUnderTest.elevation09
+
+            it("returns a expect shadowColor") {
+                let cgColor = UIColor(red: 0, green: 0, blue: 0, alpha: 1).cgColor
+                expect(attributes.shadowColor).to(equal(cgColor))
+            }
+
+            it("returns a expect shadowOffSet") {
+                expect(attributes.shadowOffSet).to(equal(.init(width: 0, height: 16)))
+            }
+
+            it("returns a expect shadowRadius") {
+                expect(attributes.shadowRadius).to(equal(24))
+            }
+
+            it("returns a expect shadowOpacity") {
+                expect(attributes.shadowOpacity).to(equal(0.14))
+            }
+        }
+
+        describe("#elevation10") {
+            let attributes = systemUnderTest.elevation10
+
+            it("returns a expect shadowColor") {
+                let cgColor = UIColor(red: 0, green: 0, blue: 0, alpha: 1).cgColor
+                expect(attributes.shadowColor).to(equal(cgColor))
+            }
+
+            it("returns a expect shadowOffSet") {
+                expect(attributes.shadowOffSet).to(equal(.init(width: 0, height: 24)))
+            }
+
+            it("returns a expect shadowRadius") {
+                expect(attributes.shadowRadius).to(equal(38))
+            }
+
+            it("returns a expect shadowOpacity") {
+                expect(attributes.shadowOpacity).to(equal(0.14))
+            }
+        }
+    }
+}

--- a/Tests/Core/SupportedBrands/Natura/NaturaThemeSpec.swift
+++ b/Tests/Core/SupportedBrands/Natura/NaturaThemeSpec.swift
@@ -62,5 +62,13 @@ final class NaturaThemeSpec: QuickSpec {
                 expect(font).to(beAnInstanceOf(NaturaFont.self))
             }
         }
+
+        describe("#elevations") {
+            it("returns a instance of NaturaElevations") {
+                let elevations = systemUnderTest.elevations
+
+                expect(elevations).to(beAnInstanceOf(NaturaElevations.self))
+            }
+        }
     }
 }

--- a/Tests/Core/SupportedBrands/TheBodyShop/TheBodyShopElevations+Spec.swift
+++ b/Tests/Core/SupportedBrands/TheBodyShop/TheBodyShopElevations+Spec.swift
@@ -1,0 +1,220 @@
+import Quick
+import Nimble
+
+@testable import NatDS
+
+final class TheBodyShopElevationsSpec: QuickSpec {
+    override func spec() {
+        let systemUnderTest = TheBodyShopElevations()
+
+        describe("#elevation01") {
+            let attributes = systemUnderTest.elevation01
+
+            it("returns a expect shadowColor") {
+                let cgColor = UIColor(red: 0, green: 0, blue: 0, alpha: 1).cgColor
+                expect(attributes.shadowColor).to(equal(cgColor))
+            }
+
+            it("returns a expect shadowOffSet") {
+                expect(attributes.shadowOffSet).to(equal(.init(width: 0, height: 1)))
+            }
+
+            it("returns a expect shadowRadius") {
+                expect(attributes.shadowRadius).to(equal(1))
+            }
+
+            it("returns a expect shadowOpacity") {
+                expect(attributes.shadowOpacity).to(equal(0.14))
+            }
+        }
+
+        describe("#elevation02") {
+            let attributes = systemUnderTest.elevation02
+
+            it("returns a expect shadowColor") {
+                let cgColor = UIColor(red: 0, green: 0, blue: 0, alpha: 1).cgColor
+                expect(attributes.shadowColor).to(equal(cgColor))
+            }
+
+            it("returns a expect shadowOffSet") {
+                expect(attributes.shadowOffSet).to(equal(.init(width: 0, height: 2)))
+            }
+
+            it("returns a expect shadowRadius") {
+                expect(attributes.shadowRadius).to(equal(2))
+            }
+
+            it("returns a expect shadowOpacity") {
+                expect(attributes.shadowOpacity).to(equal(0.14))
+            }
+        }
+
+        describe("#elevation03") {
+            let attributes = systemUnderTest.elevation03
+
+            it("returns a expect shadowColor") {
+                let cgColor = UIColor(red: 0, green: 0, blue: 0, alpha: 1).cgColor
+                expect(attributes.shadowColor).to(equal(cgColor))
+            }
+
+            it("returns a expect shadowOffSet") {
+                expect(attributes.shadowOffSet).to(equal(.init(width: 0, height: 3)))
+            }
+
+            it("returns a expect shadowRadius") {
+                expect(attributes.shadowRadius).to(equal(4))
+            }
+
+            it("returns a expect shadowOpacity") {
+                expect(attributes.shadowOpacity).to(equal(0.14))
+            }
+        }
+
+        describe("#elevation04") {
+            let attributes = systemUnderTest.elevation04
+
+            it("returns a expect shadowColor") {
+                let cgColor = UIColor(red: 0, green: 0, blue: 0, alpha: 1).cgColor
+                expect(attributes.shadowColor).to(equal(cgColor))
+            }
+
+            it("returns a expect shadowOffSet") {
+                expect(attributes.shadowOffSet).to(equal(.init(width: 0, height: 4)))
+            }
+
+            it("returns a expect shadowRadius") {
+                expect(attributes.shadowRadius).to(equal(5))
+            }
+
+            it("returns a expect shadowOpacity") {
+                expect(attributes.shadowOpacity).to(equal(0.14))
+            }
+        }
+
+        describe("#elevation05") {
+            let attributes = systemUnderTest.elevation05
+
+            it("returns a expect shadowColor") {
+                let cgColor = UIColor(red: 0, green: 0, blue: 0, alpha: 1).cgColor
+                expect(attributes.shadowColor).to(equal(cgColor))
+            }
+
+            it("returns a expect shadowOffSet") {
+                expect(attributes.shadowOffSet).to(equal(.init(width: 0, height: 6)))
+            }
+
+            it("returns a expect shadowRadius") {
+                expect(attributes.shadowRadius).to(equal(10))
+            }
+
+            it("returns a expect shadowOpacity") {
+                expect(attributes.shadowOpacity).to(equal(0.14))
+            }
+        }
+
+        describe("#elevation06") {
+            let attributes = systemUnderTest.elevation06
+
+            it("returns a expect shadowColor") {
+                let cgColor = UIColor(red: 0, green: 0, blue: 0, alpha: 1).cgColor
+                expect(attributes.shadowColor).to(equal(cgColor))
+            }
+
+            it("returns a expect shadowOffSet") {
+                expect(attributes.shadowOffSet).to(equal(.init(width: 0, height: 8)))
+            }
+
+            it("returns a expect shadowRadius") {
+                expect(attributes.shadowRadius).to(equal(10))
+            }
+
+            it("returns a expect shadowOpacity") {
+                expect(attributes.shadowOpacity).to(equal(0.14))
+            }
+        }
+
+        describe("#elevation07") {
+            let attributes = systemUnderTest.elevation07
+
+            it("returns a expect shadowColor") {
+                let cgColor = UIColor(red: 0, green: 0, blue: 0, alpha: 1).cgColor
+                expect(attributes.shadowColor).to(equal(cgColor))
+            }
+
+            it("returns a expect shadowOffSet") {
+                expect(attributes.shadowOffSet).to(equal(.init(width: 0, height: 9)))
+            }
+
+            it("returns a expect shadowRadius") {
+                expect(attributes.shadowRadius).to(equal(12))
+            }
+
+            it("returns a expect shadowOpacity") {
+                expect(attributes.shadowOpacity).to(equal(0.14))
+            }
+        }
+
+        describe("#elevation08") {
+            let attributes = systemUnderTest.elevation08
+
+            it("returns a expect shadowColor") {
+                let cgColor = UIColor(red: 0, green: 0, blue: 0, alpha: 1).cgColor
+                expect(attributes.shadowColor).to(equal(cgColor))
+            }
+
+            it("returns a expect shadowOffSet") {
+                expect(attributes.shadowOffSet).to(equal(.init(width: 0, height: 12)))
+            }
+
+            it("returns a expect shadowRadius") {
+                expect(attributes.shadowRadius).to(equal(17))
+            }
+
+            it("returns a expect shadowOpacity") {
+                expect(attributes.shadowOpacity).to(equal(0.14))
+            }
+        }
+
+        describe("#elevation09") {
+            let attributes = systemUnderTest.elevation09
+
+            it("returns a expect shadowColor") {
+                let cgColor = UIColor(red: 0, green: 0, blue: 0, alpha: 1).cgColor
+                expect(attributes.shadowColor).to(equal(cgColor))
+            }
+
+            it("returns a expect shadowOffSet") {
+                expect(attributes.shadowOffSet).to(equal(.init(width: 0, height: 16)))
+            }
+
+            it("returns a expect shadowRadius") {
+                expect(attributes.shadowRadius).to(equal(24))
+            }
+
+            it("returns a expect shadowOpacity") {
+                expect(attributes.shadowOpacity).to(equal(0.14))
+            }
+        }
+
+        describe("#elevation10") {
+            let attributes = systemUnderTest.elevation10
+
+            it("returns a expect shadowColor") {
+                let cgColor = UIColor(red: 0, green: 0, blue: 0, alpha: 1).cgColor
+                expect(attributes.shadowColor).to(equal(cgColor))
+            }
+
+            it("returns a expect shadowOffSet") {
+                expect(attributes.shadowOffSet).to(equal(.init(width: 0, height: 24)))
+            }
+
+            it("returns a expect shadowRadius") {
+                expect(attributes.shadowRadius).to(equal(38))
+            }
+
+            it("returns a expect shadowOpacity") {
+                expect(attributes.shadowOpacity).to(equal(0.14))
+            }
+        }
+    }
+}

--- a/Tests/Core/SupportedBrands/TheBodyShop/TheBodyShopTheme+Spec.swift
+++ b/Tests/Core/SupportedBrands/TheBodyShop/TheBodyShopTheme+Spec.swift
@@ -62,5 +62,13 @@ final class TheBodyShopThemeSpec: QuickSpec {
                 expect(font).to(beAnInstanceOf(TheBodyShopFont.self))
             }
         }
+
+        describe("#elevations") {
+            it("returns a instance of TheBodyShopElevations") {
+                let elevations = systemUnderTest.elevations
+
+                expect(elevations).to(beAnInstanceOf(TheBodyShopElevations.self))
+            }
+        }
     }
 }

--- a/Tests/Core/ViewStyling/ViewStyling+Spec.swift
+++ b/Tests/Core/ViewStyling/ViewStyling+Spec.swift
@@ -5,7 +5,7 @@ import Nimble
 
 final class ViewStylingSpecSpec: QuickSpec {
     override func spec() {
-        let systemUnderTest = ViewStyling()
+        let systemUnderTest = ViewStyling.self
 
         describe("#applyElevation") {
             var view: UIView!

--- a/Tests/Core/ViewStyling/ViewStyling+Spec.swift
+++ b/Tests/Core/ViewStyling/ViewStyling+Spec.swift
@@ -1,9 +1,41 @@
-//
-//  ViewStyling+Spec.swift
-//  NatDSTests
-//
-//  Created by Raoni Valadares on 14/05/20.
-//  Copyright © 2020 Natura. All rights reserved.
-//
+import Quick
+import Nimble
 
-import Foundation
+@testable import NatDS
+
+final class ViewStylingSpecSpec: QuickSpec {
+    override func spec() {
+        let systemUnderTest = ViewStyling()
+
+        describe("#applyElevation") {
+            var view: UIView!
+            let elevationAttributes: ElevationAttributes!  = ElevationAttributes(
+                shadowColor: UIColor.red.cgColor,
+                shadowOffSet: .init(width: 123, height: 321),
+                shadowRadius: 333,
+                shadowOpacity: 0.66
+            )
+
+            beforeEach {
+                view = .init(frame: .init(x: 0, y: 0, width: 200, height: 200))
+                systemUnderTest.applyElevation(onView: view, with: elevationAttributes)
+            }
+
+            it("returns a expect shadowColor") {
+                expect(view.layer.shadowColor).to(equal(elevationAttributes.shadowColor))
+            }
+
+            it("returns a expect shadowOffSet") {
+                expect(view.layer.shadowOffset).to(equal(elevationAttributes.shadowOffSet))
+            }
+
+            it("returns a expect shadowRadius") {
+                expect(view.layer.shadowRadius).to(equal(elevationAttributes.shadowRadius))
+            }
+
+            it("returns a expect shadowOpacity") {
+                expect(view.layer.shadowOpacity).to(equal(elevationAttributes.shadowOpacity))
+            }
+        }
+    }
+}

--- a/Tests/Core/ViewStyling/ViewStyling+Spec.swift
+++ b/Tests/Core/ViewStyling/ViewStyling+Spec.swift
@@ -1,0 +1,9 @@
+//
+//  ViewStyling+Spec.swift
+//  NatDSTests
+//
+//  Created by Raoni Valadares on 14/05/20.
+//  Copyright © 2020 Natura. All rights reserved.
+//
+
+import Foundation

--- a/Tests/Public/DesignTokens/NatElevations+Spec.swift
+++ b/Tests/Public/DesignTokens/NatElevations+Spec.swift
@@ -1,0 +1,295 @@
+import Quick
+import Nimble
+
+@testable import NatDS
+
+final class NatElevationsSpec: QuickSpec {
+    override func spec() {
+        let systemUnderTest = NatElevation.self
+        var view: UIView!
+
+        context("when using Avon as theme") {
+            let elevations = AvonElevations()
+
+            beforeEach {
+                DesignSystem().configure(with: .avon)
+                view = .init(frame: .init(x: 0, y: 0, width: 200, height: 200))
+            }
+
+            describe("#applyElevation") {
+                describe("#elevation01") {
+                    it("returns a expect value") {
+                        systemUnderTest.apply(onView: view, elevation: .elevation01)
+
+                        expect(view.getElevationSetted()).to(equal(elevations.elevation01))
+                    }
+                }
+
+                describe("#elevation02") {
+                    it("returns a expect value") {
+                        systemUnderTest.apply(onView: view, elevation: .elevation02)
+
+                        expect(view.getElevationSetted()).to(equal(elevations.elevation02))
+                    }
+                }
+
+                describe("#elevation03") {
+                    it("returns a expect value") {
+                        systemUnderTest.apply(onView: view, elevation: .elevation03)
+
+                        expect(view.getElevationSetted()).to(equal(elevations.elevation03))
+                    }
+                }
+
+                describe("#elevation04") {
+                    it("returns a expect value") {
+                        systemUnderTest.apply(onView: view, elevation: .elevation04)
+
+                        expect(view.getElevationSetted()).to(equal(elevations.elevation04))
+                    }
+                }
+
+                describe("#elevation05") {
+                    it("returns a expect value") {
+                        systemUnderTest.apply(onView: view, elevation: .elevation05)
+
+                        expect(view.getElevationSetted()).to(equal(elevations.elevation05))
+                    }
+                }
+
+                describe("#elevation06") {
+                    it("returns a expect value") {
+                        systemUnderTest.apply(onView: view, elevation: .elevation06)
+
+                        expect(view.getElevationSetted()).to(equal(elevations.elevation06))
+                    }
+                }
+
+                describe("#elevation07") {
+                    it("returns a expect value") {
+                        systemUnderTest.apply(onView: view, elevation: .elevation07)
+
+                        expect(view.getElevationSetted()).to(equal(elevations.elevation07))
+                    }
+                }
+
+                describe("#elevation08") {
+                    it("returns a expect value") {
+                        systemUnderTest.apply(onView: view, elevation: .elevation08)
+
+                        expect(view.getElevationSetted()).to(equal(elevations.elevation08))
+                    }
+                }
+
+                describe("#elevation09") {
+                    it("returns a expect value") {
+                        systemUnderTest.apply(onView: view, elevation: .elevation09)
+
+                        expect(view.getElevationSetted()).to(equal(elevations.elevation09))
+                    }
+                }
+
+                describe("#elevation010") {
+                    it("returns a expect value") {
+                        systemUnderTest.apply(onView: view, elevation: .elevation10)
+
+                        expect(view.getElevationSetted()).to(equal(elevations.elevation10))
+                    }
+                }
+            }
+        } // context - when using Avon as theme
+
+        context("when using Natura as theme") {
+            let elevations = NaturaElevations()
+
+            beforeEach {
+                DesignSystem().configure(with: .natura)
+                view = .init(frame: .init(x: 0, y: 0, width: 200, height: 200))
+            }
+
+            describe("#applyElevation") {
+                describe("#elevation01") {
+                    it("returns a expect value") {
+                        systemUnderTest.apply(onView: view, elevation: .elevation01)
+
+                        expect(view.getElevationSetted()).to(equal(elevations.elevation01))
+                    }
+                }
+
+                describe("#elevation02") {
+                    it("returns a expect value") {
+                        systemUnderTest.apply(onView: view, elevation: .elevation02)
+
+                        expect(view.getElevationSetted()).to(equal(elevations.elevation02))
+                    }
+                }
+
+                describe("#elevation03") {
+                    it("returns a expect value") {
+                        systemUnderTest.apply(onView: view, elevation: .elevation03)
+
+                        expect(view.getElevationSetted()).to(equal(elevations.elevation03))
+                    }
+                }
+
+                describe("#elevation04") {
+                    it("returns a expect value") {
+                        systemUnderTest.apply(onView: view, elevation: .elevation04)
+
+                        expect(view.getElevationSetted()).to(equal(elevations.elevation04))
+                    }
+                }
+
+                describe("#elevation05") {
+                    it("returns a expect value") {
+                        systemUnderTest.apply(onView: view, elevation: .elevation05)
+
+                        expect(view.getElevationSetted()).to(equal(elevations.elevation05))
+                    }
+                }
+
+                describe("#elevation06") {
+                    it("returns a expect value") {
+                        systemUnderTest.apply(onView: view, elevation: .elevation06)
+
+                        expect(view.getElevationSetted()).to(equal(elevations.elevation06))
+                    }
+                }
+
+                describe("#elevation07") {
+                    it("returns a expect value") {
+                        systemUnderTest.apply(onView: view, elevation: .elevation07)
+
+                        expect(view.getElevationSetted()).to(equal(elevations.elevation07))
+                    }
+                }
+
+                describe("#elevation08") {
+                    it("returns a expect value") {
+                        systemUnderTest.apply(onView: view, elevation: .elevation08)
+
+                        expect(view.getElevationSetted()).to(equal(elevations.elevation08))
+                    }
+                }
+
+                describe("#elevation09") {
+                    it("returns a expect value") {
+                        systemUnderTest.apply(onView: view, elevation: .elevation09)
+
+                        expect(view.getElevationSetted()).to(equal(elevations.elevation09))
+                    }
+                }
+
+                describe("#elevation010") {
+                    it("returns a expect value") {
+                        systemUnderTest.apply(onView: view, elevation: .elevation10)
+
+                        expect(view.getElevationSetted()).to(equal(elevations.elevation10))
+                    }
+                }
+            }
+        } // context - when using Natura as theme
+
+        context("when using TheBodyShop as theme") {
+            let elevations = TheBodyShopElevations()
+
+            beforeEach {
+                DesignSystem().configure(with: .theBodyShop)
+                view = .init(frame: .init(x: 0, y: 0, width: 200, height: 200))
+            }
+
+            describe("#applyElevation") {
+                describe("#elevation01") {
+                    it("returns a expect value") {
+                        systemUnderTest.apply(onView: view, elevation: .elevation01)
+
+                        expect(view.getElevationSetted()).to(equal(elevations.elevation01))
+                    }
+                }
+
+                describe("#elevation02") {
+                    it("returns a expect value") {
+                        systemUnderTest.apply(onView: view, elevation: .elevation02)
+
+                        expect(view.getElevationSetted()).to(equal(elevations.elevation02))
+                    }
+                }
+
+                describe("#elevation03") {
+                    it("returns a expect value") {
+                        systemUnderTest.apply(onView: view, elevation: .elevation03)
+
+                        expect(view.getElevationSetted()).to(equal(elevations.elevation03))
+                    }
+                }
+
+                describe("#elevation04") {
+                    it("returns a expect value") {
+                        systemUnderTest.apply(onView: view, elevation: .elevation04)
+
+                        expect(view.getElevationSetted()).to(equal(elevations.elevation04))
+                    }
+                }
+
+                describe("#elevation05") {
+                    it("returns a expect value") {
+                        systemUnderTest.apply(onView: view, elevation: .elevation05)
+
+                        expect(view.getElevationSetted()).to(equal(elevations.elevation05))
+                    }
+                }
+
+                describe("#elevation06") {
+                    it("returns a expect value") {
+                        systemUnderTest.apply(onView: view, elevation: .elevation06)
+
+                        expect(view.getElevationSetted()).to(equal(elevations.elevation06))
+                    }
+                }
+
+                describe("#elevation07") {
+                    it("returns a expect value") {
+                        systemUnderTest.apply(onView: view, elevation: .elevation07)
+
+                        expect(view.getElevationSetted()).to(equal(elevations.elevation07))
+                    }
+                }
+
+                describe("#elevation08") {
+                    it("returns a expect value") {
+                        systemUnderTest.apply(onView: view, elevation: .elevation08)
+
+                        expect(view.getElevationSetted()).to(equal(elevations.elevation08))
+                    }
+                }
+
+                describe("#elevation09") {
+                    it("returns a expect value") {
+                        systemUnderTest.apply(onView: view, elevation: .elevation09)
+
+                        expect(view.getElevationSetted()).to(equal(elevations.elevation09))
+                    }
+                }
+
+                describe("#elevation010") {
+                    it("returns a expect value") {
+                        systemUnderTest.apply(onView: view, elevation: .elevation10)
+
+                        expect(view.getElevationSetted()).to(equal(elevations.elevation10))
+                    }
+                }
+            }
+        } // context - when using TheBodyShop as theme
+    }
+}
+
+fileprivate extension UIView {
+    func getElevationSetted() -> ElevationAttributes {
+        .init(
+            shadowColor: layer.shadowColor!,
+            shadowOffSet: layer.shadowOffset,
+            shadowRadius: layer.shadowRadius,
+            shadowOpacity: layer.shadowOpacity
+        )
+    }
+}

--- a/Tests/Supporting Files/TestingHelpers/ElevationAttributes+Equitable.swift
+++ b/Tests/Supporting Files/TestingHelpers/ElevationAttributes+Equitable.swift
@@ -1,0 +1,10 @@
+@testable import NatDS
+
+extension ElevationAttributes: Equatable {
+    public static func == (lhs: ElevationAttributes, rhs: ElevationAttributes) -> Bool {
+        lhs.shadowColor == rhs.shadowColor &&
+        lhs.shadowOffSet == rhs.shadowOffSet &&
+        lhs.shadowRadius == rhs.shadowRadius &&
+        lhs.shadowOpacity == rhs.shadowOpacity
+    }
+}


### PR DESCRIPTION
# Description

- Adds `NatElevations`, to apply shadow elements to a view layer making a visual elevation effect.
- Adds visual representation of `NatElevations` at sample app.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update




![Simulator Screen Shot - iPhone SE - 2020-05-15 at 13 32 17](https://user-images.githubusercontent.com/12799353/82074042-88b20500-96b0-11ea-86c6-b4d4f1b6b2ae.png)
