### PR TITLE
Changes parameters names from `onView:` or `onButton:` to just `on:`

### DIFF
--- a/SampleApp/Sources/Sample/Design/Elevation/Cells/ElevationCell.swift
+++ b/SampleApp/Sources/Sample/Design/Elevation/Cells/ElevationCell.swift
@@ -53,7 +53,7 @@ final class ElevationCell: UITableViewCell {
         label.text = description
 
         if let elevation = elevation {
-            NatElevation.apply(onView: symbolicView, elevation: elevation)
+            NatElevation.apply(on: symbolicView, elevation: elevation)
         }
     }
     // MARK: - Private methods

--- a/Sources/Core/ViewStyling/ViewStyle.swift
+++ b/Sources/Core/ViewStyling/ViewStyle.swift
@@ -1,5 +1,5 @@
 enum ViewStyle {
-    static func applyElevation(onView view: UIView, with attributtes: ElevationAttributes) {
+    static func applyElevation(on view: UIView, with attributtes: ElevationAttributes) {
         view.layer.shadowColor = attributtes.shadowColor
         view.layer.shadowOffset = attributtes.shadowOffSet
         view.layer.shadowRadius = attributtes.shadowRadius

--- a/Sources/Public/Components/Button/NatButton/NatButton.swift
+++ b/Sources/Public/Components/Button/NatButton/NatButton.swift
@@ -86,15 +86,15 @@ public final class NatButton: UIButton, Pulsable {
         }
     }
 
-    public override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
-        super.traitCollectionDidChange(previousTraitCollection)
-
-        style.changeState(self)
-    }
-
     public override func touchesEnded(_ touches: Set<UITouch>, with event: UIEvent?) {
         super.touchesEnded(touches, with: event)
 
         endPulse(layer: layer)
+    }
+
+    public override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+
+        style.changeState(self)
     }
 }

--- a/Sources/Public/DesignTokens/NatElevation.swift
+++ b/Sources/Public/DesignTokens/NatElevation.swift
@@ -15,10 +15,10 @@
 */
 
 public struct NatElevation {
-    public static func apply(onView view: UIView, elevation: Elevation) {
+    public static func apply(on view: UIView, elevation: Elevation) {
         let attributes = getTheme().elevations[keyPath: elevation.rawValue]
 
-        ViewStyle.applyElevation(onView: view, with: attributes)
+        ViewStyle.applyElevation(on: view, with: attributes)
     }
 }
 

--- a/Tests/Core/ViewStyle/ViewStyle+Spec.swift
+++ b/Tests/Core/ViewStyle/ViewStyle+Spec.swift
@@ -18,7 +18,7 @@ final class ViewStyleSpecSpec: QuickSpec {
 
             beforeEach {
                 view = .init(frame: .init(x: 0, y: 0, width: 200, height: 200))
-                systemUnderTest.applyElevation(onView: view, with: elevationAttributes)
+                systemUnderTest.applyElevation(on: view, with: elevationAttributes)
             }
 
             it("returns a expect shadowColor") {

--- a/Tests/Public/DesignTokens/NatElevations+Spec.swift
+++ b/Tests/Public/DesignTokens/NatElevations+Spec.swift
@@ -19,7 +19,7 @@ final class NatElevationsSpec: QuickSpec {
             describe("#applyElevation") {
                 describe("#elevation01") {
                     it("returns a expect value") {
-                        systemUnderTest.apply(onView: view, elevation: .elevation01)
+                        systemUnderTest.apply(on: view, elevation: .elevation01)
 
                         expect(view.getElevationSetted()).to(equal(elevations.elevation01))
                     }
@@ -27,7 +27,7 @@ final class NatElevationsSpec: QuickSpec {
 
                 describe("#elevation02") {
                     it("returns a expect value") {
-                        systemUnderTest.apply(onView: view, elevation: .elevation02)
+                        systemUnderTest.apply(on: view, elevation: .elevation02)
 
                         expect(view.getElevationSetted()).to(equal(elevations.elevation02))
                     }
@@ -35,7 +35,7 @@ final class NatElevationsSpec: QuickSpec {
 
                 describe("#elevation03") {
                     it("returns a expect value") {
-                        systemUnderTest.apply(onView: view, elevation: .elevation03)
+                        systemUnderTest.apply(on: view, elevation: .elevation03)
 
                         expect(view.getElevationSetted()).to(equal(elevations.elevation03))
                     }
@@ -43,7 +43,7 @@ final class NatElevationsSpec: QuickSpec {
 
                 describe("#elevation04") {
                     it("returns a expect value") {
-                        systemUnderTest.apply(onView: view, elevation: .elevation04)
+                        systemUnderTest.apply(on: view, elevation: .elevation04)
 
                         expect(view.getElevationSetted()).to(equal(elevations.elevation04))
                     }
@@ -51,7 +51,7 @@ final class NatElevationsSpec: QuickSpec {
 
                 describe("#elevation05") {
                     it("returns a expect value") {
-                        systemUnderTest.apply(onView: view, elevation: .elevation05)
+                        systemUnderTest.apply(on: view, elevation: .elevation05)
 
                         expect(view.getElevationSetted()).to(equal(elevations.elevation05))
                     }
@@ -59,7 +59,7 @@ final class NatElevationsSpec: QuickSpec {
 
                 describe("#elevation06") {
                     it("returns a expect value") {
-                        systemUnderTest.apply(onView: view, elevation: .elevation06)
+                        systemUnderTest.apply(on: view, elevation: .elevation06)
 
                         expect(view.getElevationSetted()).to(equal(elevations.elevation06))
                     }
@@ -67,7 +67,7 @@ final class NatElevationsSpec: QuickSpec {
 
                 describe("#elevation07") {
                     it("returns a expect value") {
-                        systemUnderTest.apply(onView: view, elevation: .elevation07)
+                        systemUnderTest.apply(on: view, elevation: .elevation07)
 
                         expect(view.getElevationSetted()).to(equal(elevations.elevation07))
                     }
@@ -75,7 +75,7 @@ final class NatElevationsSpec: QuickSpec {
 
                 describe("#elevation08") {
                     it("returns a expect value") {
-                        systemUnderTest.apply(onView: view, elevation: .elevation08)
+                        systemUnderTest.apply(on: view, elevation: .elevation08)
 
                         expect(view.getElevationSetted()).to(equal(elevations.elevation08))
                     }
@@ -83,7 +83,7 @@ final class NatElevationsSpec: QuickSpec {
 
                 describe("#elevation09") {
                     it("returns a expect value") {
-                        systemUnderTest.apply(onView: view, elevation: .elevation09)
+                        systemUnderTest.apply(on: view, elevation: .elevation09)
 
                         expect(view.getElevationSetted()).to(equal(elevations.elevation09))
                     }
@@ -91,7 +91,7 @@ final class NatElevationsSpec: QuickSpec {
 
                 describe("#elevation010") {
                     it("returns a expect value") {
-                        systemUnderTest.apply(onView: view, elevation: .elevation10)
+                        systemUnderTest.apply(on: view, elevation: .elevation10)
 
                         expect(view.getElevationSetted()).to(equal(elevations.elevation10))
                     }
@@ -110,7 +110,7 @@ final class NatElevationsSpec: QuickSpec {
             describe("#applyElevation") {
                 describe("#elevation01") {
                     it("returns a expect value") {
-                        systemUnderTest.apply(onView: view, elevation: .elevation01)
+                        systemUnderTest.apply(on: view, elevation: .elevation01)
 
                         expect(view.getElevationSetted()).to(equal(elevations.elevation01))
                     }
@@ -118,7 +118,7 @@ final class NatElevationsSpec: QuickSpec {
 
                 describe("#elevation02") {
                     it("returns a expect value") {
-                        systemUnderTest.apply(onView: view, elevation: .elevation02)
+                        systemUnderTest.apply(on: view, elevation: .elevation02)
 
                         expect(view.getElevationSetted()).to(equal(elevations.elevation02))
                     }
@@ -126,7 +126,7 @@ final class NatElevationsSpec: QuickSpec {
 
                 describe("#elevation03") {
                     it("returns a expect value") {
-                        systemUnderTest.apply(onView: view, elevation: .elevation03)
+                        systemUnderTest.apply(on: view, elevation: .elevation03)
 
                         expect(view.getElevationSetted()).to(equal(elevations.elevation03))
                     }
@@ -134,7 +134,7 @@ final class NatElevationsSpec: QuickSpec {
 
                 describe("#elevation04") {
                     it("returns a expect value") {
-                        systemUnderTest.apply(onView: view, elevation: .elevation04)
+                        systemUnderTest.apply(on: view, elevation: .elevation04)
 
                         expect(view.getElevationSetted()).to(equal(elevations.elevation04))
                     }
@@ -142,7 +142,7 @@ final class NatElevationsSpec: QuickSpec {
 
                 describe("#elevation05") {
                     it("returns a expect value") {
-                        systemUnderTest.apply(onView: view, elevation: .elevation05)
+                        systemUnderTest.apply(on: view, elevation: .elevation05)
 
                         expect(view.getElevationSetted()).to(equal(elevations.elevation05))
                     }
@@ -150,7 +150,7 @@ final class NatElevationsSpec: QuickSpec {
 
                 describe("#elevation06") {
                     it("returns a expect value") {
-                        systemUnderTest.apply(onView: view, elevation: .elevation06)
+                        systemUnderTest.apply(on: view, elevation: .elevation06)
 
                         expect(view.getElevationSetted()).to(equal(elevations.elevation06))
                     }
@@ -158,7 +158,7 @@ final class NatElevationsSpec: QuickSpec {
 
                 describe("#elevation07") {
                     it("returns a expect value") {
-                        systemUnderTest.apply(onView: view, elevation: .elevation07)
+                        systemUnderTest.apply(on: view, elevation: .elevation07)
 
                         expect(view.getElevationSetted()).to(equal(elevations.elevation07))
                     }
@@ -166,7 +166,7 @@ final class NatElevationsSpec: QuickSpec {
 
                 describe("#elevation08") {
                     it("returns a expect value") {
-                        systemUnderTest.apply(onView: view, elevation: .elevation08)
+                        systemUnderTest.apply(on: view, elevation: .elevation08)
 
                         expect(view.getElevationSetted()).to(equal(elevations.elevation08))
                     }
@@ -174,7 +174,7 @@ final class NatElevationsSpec: QuickSpec {
 
                 describe("#elevation09") {
                     it("returns a expect value") {
-                        systemUnderTest.apply(onView: view, elevation: .elevation09)
+                        systemUnderTest.apply(on: view, elevation: .elevation09)
 
                         expect(view.getElevationSetted()).to(equal(elevations.elevation09))
                     }
@@ -182,7 +182,7 @@ final class NatElevationsSpec: QuickSpec {
 
                 describe("#elevation010") {
                     it("returns a expect value") {
-                        systemUnderTest.apply(onView: view, elevation: .elevation10)
+                        systemUnderTest.apply(on: view, elevation: .elevation10)
 
                         expect(view.getElevationSetted()).to(equal(elevations.elevation10))
                     }
@@ -201,7 +201,7 @@ final class NatElevationsSpec: QuickSpec {
             describe("#applyElevation") {
                 describe("#elevation01") {
                     it("returns a expect value") {
-                        systemUnderTest.apply(onView: view, elevation: .elevation01)
+                        systemUnderTest.apply(on: view, elevation: .elevation01)
 
                         expect(view.getElevationSetted()).to(equal(elevations.elevation01))
                     }
@@ -209,7 +209,7 @@ final class NatElevationsSpec: QuickSpec {
 
                 describe("#elevation02") {
                     it("returns a expect value") {
-                        systemUnderTest.apply(onView: view, elevation: .elevation02)
+                        systemUnderTest.apply(on: view, elevation: .elevation02)
 
                         expect(view.getElevationSetted()).to(equal(elevations.elevation02))
                     }
@@ -217,7 +217,7 @@ final class NatElevationsSpec: QuickSpec {
 
                 describe("#elevation03") {
                     it("returns a expect value") {
-                        systemUnderTest.apply(onView: view, elevation: .elevation03)
+                        systemUnderTest.apply(on: view, elevation: .elevation03)
 
                         expect(view.getElevationSetted()).to(equal(elevations.elevation03))
                     }
@@ -225,7 +225,7 @@ final class NatElevationsSpec: QuickSpec {
 
                 describe("#elevation04") {
                     it("returns a expect value") {
-                        systemUnderTest.apply(onView: view, elevation: .elevation04)
+                        systemUnderTest.apply(on: view, elevation: .elevation04)
 
                         expect(view.getElevationSetted()).to(equal(elevations.elevation04))
                     }
@@ -233,7 +233,7 @@ final class NatElevationsSpec: QuickSpec {
 
                 describe("#elevation05") {
                     it("returns a expect value") {
-                        systemUnderTest.apply(onView: view, elevation: .elevation05)
+                        systemUnderTest.apply(on: view, elevation: .elevation05)
 
                         expect(view.getElevationSetted()).to(equal(elevations.elevation05))
                     }
@@ -241,7 +241,7 @@ final class NatElevationsSpec: QuickSpec {
 
                 describe("#elevation06") {
                     it("returns a expect value") {
-                        systemUnderTest.apply(onView: view, elevation: .elevation06)
+                        systemUnderTest.apply(on: view, elevation: .elevation06)
 
                         expect(view.getElevationSetted()).to(equal(elevations.elevation06))
                     }
@@ -249,7 +249,7 @@ final class NatElevationsSpec: QuickSpec {
 
                 describe("#elevation07") {
                     it("returns a expect value") {
-                        systemUnderTest.apply(onView: view, elevation: .elevation07)
+                        systemUnderTest.apply(on: view, elevation: .elevation07)
 
                         expect(view.getElevationSetted()).to(equal(elevations.elevation07))
                     }
@@ -257,7 +257,7 @@ final class NatElevationsSpec: QuickSpec {
 
                 describe("#elevation08") {
                     it("returns a expect value") {
-                        systemUnderTest.apply(onView: view, elevation: .elevation08)
+                        systemUnderTest.apply(on: view, elevation: .elevation08)
 
                         expect(view.getElevationSetted()).to(equal(elevations.elevation08))
                     }
@@ -265,7 +265,7 @@ final class NatElevationsSpec: QuickSpec {
 
                 describe("#elevation09") {
                     it("returns a expect value") {
-                        systemUnderTest.apply(onView: view, elevation: .elevation09)
+                        systemUnderTest.apply(on: view, elevation: .elevation09)
 
                         expect(view.getElevationSetted()).to(equal(elevations.elevation09))
                     }
@@ -273,7 +273,7 @@ final class NatElevationsSpec: QuickSpec {
 
                 describe("#elevation010") {
                     it("returns a expect value") {
-                        systemUnderTest.apply(onView: view, elevation: .elevation10)
+                        systemUnderTest.apply(on: view, elevation: .elevation10)
 
                         expect(view.getElevationSetted()).to(equal(elevations.elevation10))
                     }


### PR DESCRIPTION
# Description

Changes parameters names from `onView:` or `onButton:` to just `on:`

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Internal changes
