### PR TITLE
[DSY-412] Updates Natbutton: Colors for disabled + EdgeInsets.

### DIFF
--- a/NatDS.xcodeproj/project.pbxproj
+++ b/NatDS.xcodeproj/project.pbxproj
@@ -213,6 +213,7 @@
 		84C1CACB249A8AB00041A511 /* DialogStandardStyle+FooterView+Spec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84C1CACA249A8AB00041A511 /* DialogStandardStyle+FooterView+Spec.swift */; };
 		84C1CACE249A93940041A511 /* NatDialogController+Snapshot+Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84C1CACD249A93940041A511 /* NatDialogController+Snapshot+Tests.swift */; };
 		84C1CAD0249B9A230041A511 /* DialogStandardStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84C1CACF249B9A230041A511 /* DialogStandardStyle.swift */; };
+		84C1CAD2249D00DD0041A511 /* NatButton+EdgeInsets.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84C1CAD1249D00DD0041A511 /* NatButton+EdgeInsets.swift */; };
 		84C24DA6246F3DE40046833B /* NatButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84C24DA5246F3DE40046833B /* NatButton.swift */; };
 		84EE85E9245A0FB20009293A /* NatSpacing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84EE85E8245A0FB20009293A /* NatSpacing.swift */; };
 		A9325A6623FB34EC0023979C /* UICollectionView+Reusable.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9325A6523FB34EC0023979C /* UICollectionView+Reusable.swift */; };
@@ -452,6 +453,7 @@
 		84C1CACA249A8AB00041A511 /* DialogStandardStyle+FooterView+Spec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DialogStandardStyle+FooterView+Spec.swift"; sourceTree = "<group>"; };
 		84C1CACD249A93940041A511 /* NatDialogController+Snapshot+Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NatDialogController+Snapshot+Tests.swift"; sourceTree = "<group>"; };
 		84C1CACF249B9A230041A511 /* DialogStandardStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DialogStandardStyle.swift; sourceTree = "<group>"; };
+		84C1CAD1249D00DD0041A511 /* NatButton+EdgeInsets.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NatButton+EdgeInsets.swift"; sourceTree = "<group>"; };
 		84C24DA5246F3DE40046833B /* NatButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NatButton.swift; sourceTree = "<group>"; };
 		84EE85E8245A0FB20009293A /* NatSpacing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NatSpacing.swift; sourceTree = "<group>"; };
 		9A46395C038D4497A880A6FF /* Pods-NatDSTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NatDSTests.release.xcconfig"; path = "Target Support Files/Pods-NatDSTests/Pods-NatDSTests.release.xcconfig"; sourceTree = "<group>"; };
@@ -1175,6 +1177,7 @@
 				84C24DA5246F3DE40046833B /* NatButton.swift */,
 				84B197A2247593B500F1B575 /* NatButton+Style.swift */,
 				84391CAE247BF85F00803545 /* NatButton+Height.swift */,
+				84C1CAD1249D00DD0041A511 /* NatButton+EdgeInsets.swift */,
 			);
 			path = NatButton;
 			sourceTree = "<group>";
@@ -1703,6 +1706,7 @@
 				84692865247FEB0D008DF255 /* AvonColorPaletteLight.swift in Sources */,
 				84428F87245B205D00D46611 /* Space.swift in Sources */,
 				84BFB6282469B92000506ED1 /* TheBodyShopFont.swift in Sources */,
+				84C1CAD2249D00DD0041A511 /* NatButton+EdgeInsets.swift in Sources */,
 				110F55B323BE5A3F00B9937A /* ContainedButton.swift in Sources */,
 				843FA2B62464724C00D20D9A /* AvonOpacities.swift in Sources */,
 				84428F83245B03FD00D46611 /* AvonSpacing.swift in Sources */,

--- a/NatDS.xcodeproj/project.pbxproj
+++ b/NatDS.xcodeproj/project.pbxproj
@@ -214,6 +214,7 @@
 		84C1CACE249A93940041A511 /* NatDialogController+Snapshot+Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84C1CACD249A93940041A511 /* NatDialogController+Snapshot+Tests.swift */; };
 		84C1CAD0249B9A230041A511 /* DialogStandardStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84C1CACF249B9A230041A511 /* DialogStandardStyle.swift */; };
 		84C1CAD2249D00DD0041A511 /* NatButton+EdgeInsets.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84C1CAD1249D00DD0041A511 /* NatButton+EdgeInsets.swift */; };
+		84C1CAD4249D2ED90041A511 /* NatButton+EdgeInsets+Spec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84C1CAD3249D2ED90041A511 /* NatButton+EdgeInsets+Spec.swift */; };
 		84C24DA6246F3DE40046833B /* NatButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84C24DA5246F3DE40046833B /* NatButton.swift */; };
 		84EE85E9245A0FB20009293A /* NatSpacing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84EE85E8245A0FB20009293A /* NatSpacing.swift */; };
 		A9325A6623FB34EC0023979C /* UICollectionView+Reusable.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9325A6523FB34EC0023979C /* UICollectionView+Reusable.swift */; };
@@ -454,6 +455,7 @@
 		84C1CACD249A93940041A511 /* NatDialogController+Snapshot+Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NatDialogController+Snapshot+Tests.swift"; sourceTree = "<group>"; };
 		84C1CACF249B9A230041A511 /* DialogStandardStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DialogStandardStyle.swift; sourceTree = "<group>"; };
 		84C1CAD1249D00DD0041A511 /* NatButton+EdgeInsets.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NatButton+EdgeInsets.swift"; sourceTree = "<group>"; };
+		84C1CAD3249D2ED90041A511 /* NatButton+EdgeInsets+Spec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NatButton+EdgeInsets+Spec.swift"; sourceTree = "<group>"; };
 		84C24DA5246F3DE40046833B /* NatButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NatButton.swift; sourceTree = "<group>"; };
 		84EE85E8245A0FB20009293A /* NatSpacing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NatSpacing.swift; sourceTree = "<group>"; };
 		9A46395C038D4497A880A6FF /* Pods-NatDSTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NatDSTests.release.xcconfig"; path = "Target Support Files/Pods-NatDSTests/Pods-NatDSTests.release.xcconfig"; sourceTree = "<group>"; };
@@ -525,6 +527,7 @@
 				43F1DD4A24183B8F005A0C4A /* PulseLayerTests.swift */,
 				84391CA72477019100803545 /* NatButton+Specs.swift */,
 				84391CAA247B220200803545 /* NatButton+Height+Spec.swift */,
+				84C1CAD3249D2ED90041A511 /* NatButton+EdgeInsets+Spec.swift */,
 			);
 			path = Button;
 			sourceTree = "<group>";
@@ -1810,6 +1813,7 @@
 				11518B6C2396C4AB00220570 /* NavigationDrawerTests.swift in Sources */,
 				64DF47E523FB4A5600DAF441 /* TextFieldTypeTests.swift in Sources */,
 				8427A2B52450ED6600CF30D5 /* UIColor+AsHexString.swift in Sources */,
+				84C1CAD4249D2ED90041A511 /* NatButton+EdgeInsets+Spec.swift in Sources */,
 				8427A2D42451DE7C00CF30D5 /* NaturaColorPaletteDark+Spec.swift in Sources */,
 				8427A2C62451CEF500CF30D5 /* AvonThemeSpec.swift in Sources */,
 				846313AE245CE9AE00387FCF /* GetTheme+Spec.swift in Sources */,

--- a/Sources/Core/ViewStyling/Button/ButtonContainedStyle.swift
+++ b/Sources/Core/ViewStyling/Button/ButtonContainedStyle.swift
@@ -10,7 +10,7 @@ enum ButtonContainedStyle {
             button.backgroundColor = NatColors.primary
             NatElevation.apply(on: button, elevation: .elevation02)
         case .disabled:
-            button.backgroundColor = NatColors.onSurface.withAlphaComponent(NatOpacities.opacity03)
+            button.backgroundColor = NatColors.onSurface.withAlphaComponent(NatOpacities.opacity02)
             NatElevation.apply(on: button, elevation: .none)
         default: break
         }

--- a/Sources/Core/ViewStyling/Button/ButtonStyle.swift
+++ b/Sources/Core/ViewStyling/Button/ButtonStyle.swift
@@ -5,13 +5,7 @@ enum ButtonStyle {
 
         button.layer.cornerRadius = NatBorderRadius.medium
 
-        let spacing = getTheme().spacing.small
-        button.contentEdgeInsets = UIEdgeInsets(
-            top: spacing,
-            left: spacing,
-            bottom: spacing,
-            right: spacing
-        )
+        button.contentEdgeInsets = NatButton.EdgeInsets.medium
     }
 
     static func applyStyleForTitle(
@@ -25,7 +19,7 @@ enum ButtonStyle {
         )
         let titleForDisabled = createTextForTitle(
             text: title,
-            withColor: NatColors.onSurface.withAlphaComponent(getTheme().opacities.opacity06)
+            withColor: NatColors.onSurface.withAlphaComponent(getTheme().opacities.opacity08)
         )
 
         button.setAttributedTitle(titleForNormal, for: .normal)

--- a/Sources/Public/Components/Button/NatButton/NatButton+EdgeInsets.swift
+++ b/Sources/Public/Components/Button/NatButton/NatButton+EdgeInsets.swift
@@ -4,13 +4,13 @@ extension NatButton {
 
         These are all edgeInsets allowed for a NatButton:
         - small
-        - medium
+        - medium (default)
         - large
 
         usage example:
 
             let button = NatButton(style: .contained)
-            button.contentEdgeInsets = .small
+            button.contentEdgeInsets = NatButton.EdgeInsets.medium
 
      - Requires:
             It's necessary to configure the Design System current Brand at DesignSystem class
@@ -20,9 +20,9 @@ extension NatButton {
     */
 
     public enum EdgeInsets {
-        public static var small: UIEdgeInsets { .init(spacing: getTheme().spacing.small) }
-        public static var medium: UIEdgeInsets { .init(spacing: getTheme().spacing.small) }
-        public static var large: UIEdgeInsets { .init(spacing: getTheme().spacing.small) }
+        public static var small: UIEdgeInsets { .init(spacing: 8) }
+        public static var medium: UIEdgeInsets { .init(spacing: 12) }
+        public static var large: UIEdgeInsets { .init(spacing: 16) }
     }
 }
 

--- a/Sources/Public/Components/Button/NatButton/NatButton+EdgeInsets.swift
+++ b/Sources/Public/Components/Button/NatButton/NatButton+EdgeInsets.swift
@@ -1,0 +1,38 @@
+extension NatButton {
+    /**
+      EdgeInsets is a enum that represents contentEdgeInsets values of button component.
+
+        These are all edgeInsets allowed for a NatButton:
+        - small
+        - medium
+        - large
+
+        usage example:
+
+            let button = NatButton(style: .contained)
+            button.contentEdgeInsets = .small
+
+     - Requires:
+            It's necessary to configure the Design System current Brand at DesignSystem class
+            or fatalError will be raised.
+
+                DesignSystem().configure(with: Brand)
+    */
+
+    public enum EdgeInsets {
+        public static var small: UIEdgeInsets { .init(spacing: getTheme().spacing.small) }
+        public static var medium: UIEdgeInsets { .init(spacing: getTheme().spacing.small) }
+        public static var large: UIEdgeInsets { .init(spacing: getTheme().spacing.small) }
+    }
+}
+
+private extension UIEdgeInsets {
+    init(spacing: CGFloat) {
+        self.init(
+            top: spacing,
+            left: spacing,
+            bottom: spacing,
+            right: spacing
+        )
+    }
+}

--- a/Sources/Public/Components/Button/NatButton/NatButton+Height.swift
+++ b/Sources/Public/Components/Button/NatButton/NatButton+Height.swift
@@ -2,7 +2,7 @@ extension NatButton {
     /**
       Height is a enum that represents height values for the button component.
 
-        This is all sizes allowed for a NatButton:
+        These are all sizes allowed for a NatButton:
         - small
         - medium
         - large

--- a/Sources/Public/Components/Button/NatButton/NatButton+Height.swift
+++ b/Sources/Public/Components/Button/NatButton/NatButton+Height.swift
@@ -4,7 +4,7 @@ extension NatButton {
 
         These are all sizes allowed for a NatButton:
         - small
-        - medium
+        - medium (should be default)
         - large
 
         usage example:

--- a/Tests/Core/ViewStyle/Button/ButtonContainedStyle+Spec.swift
+++ b/Tests/Core/ViewStyle/Button/ButtonContainedStyle+Spec.swift
@@ -47,7 +47,7 @@ final class ButtonContainedStyleSpec: QuickSpec {
             }
 
             it("returns an expected contentEdgeInsets") {
-                let spacing = getTheme().spacing.small
+                let spacing: CGFloat = 12
 
                 expect(button.contentEdgeInsets.top).to(equal(spacing))
                 expect(button.contentEdgeInsets.right).to(equal(spacing))
@@ -87,7 +87,7 @@ final class ButtonContainedStyleSpec: QuickSpec {
                 }
 
                 it("returns an expected backgroundColor") {
-                    let expectedColor = getTheme().colors.onSurface.withAlphaComponent(NatOpacities.opacity03)
+                    let expectedColor = getTheme().colors.onSurface.withAlphaComponent(NatOpacities.opacity02)
 
                     expect(button.backgroundColor).to(equal(expectedColor))
                 }
@@ -156,7 +156,7 @@ final class ButtonContainedStyleSpec: QuickSpec {
                     let foregroundColor = attributes[.foregroundColor] as? UIColor
 
                     expect(foregroundColor)
-                        .to(equal(NatColors.onSurface.withAlphaComponent(NatOpacities.opacity06)))
+                        .to(equal(NatColors.onSurface.withAlphaComponent(NatOpacities.opacity08)))
                 }
             }
         }

--- a/Tests/Core/ViewStyle/Button/ButtonOutlinedStyle+Spec.swift
+++ b/Tests/Core/ViewStyle/Button/ButtonOutlinedStyle+Spec.swift
@@ -44,7 +44,7 @@ final class ButtonOutlinedStyleSpec: QuickSpec {
             }
 
             it("returns an expected contentEdgeInsets") {
-                let spacing = getTheme().spacing.small
+                let spacing: CGFloat = 12
 
                 expect(button.contentEdgeInsets.top).to(equal(spacing))
                 expect(button.contentEdgeInsets.right).to(equal(spacing))
@@ -141,7 +141,7 @@ final class ButtonOutlinedStyleSpec: QuickSpec {
                     let foregroundColor = attributes[.foregroundColor] as? UIColor
 
                     expect(foregroundColor)
-                        .to(equal(NatColors.onSurface.withAlphaComponent(getTheme().opacities.opacity06)))
+                        .to(equal(NatColors.onSurface.withAlphaComponent(getTheme().opacities.opacity08)))
                 }
             }
         }

--- a/Tests/Core/ViewStyle/Button/ButtonStyle+Spec.swift
+++ b/Tests/Core/ViewStyle/Button/ButtonStyle+Spec.swift
@@ -44,7 +44,7 @@ final class ButtonStyleSpec: QuickSpec {
             }
 
             it("returns an expected contentEdgeInsets") {
-                let spacing = getTheme().spacing.small
+                let spacing: CGFloat = 12
 
                 expect(button.contentEdgeInsets.top).to(equal(spacing))
                 expect(button.contentEdgeInsets.right).to(equal(spacing))
@@ -111,7 +111,7 @@ final class ButtonStyleSpec: QuickSpec {
                 it("returns an expected foregroundColor") {
                     let foregroundColor = attributes[.foregroundColor] as? UIColor
                     let expectedColor = getTheme().colors.onSurface
-                        .withAlphaComponent(getTheme().opacities.opacity06)
+                        .withAlphaComponent(getTheme().opacities.opacity08)
 
                     expect(foregroundColor).to(equal(expectedColor))
                 }

--- a/Tests/Core/ViewStyle/Button/ButtonTextStyle+Spec.swift
+++ b/Tests/Core/ViewStyle/Button/ButtonTextStyle+Spec.swift
@@ -45,7 +45,7 @@ final class ButtonTextStyleSpec: QuickSpec {
             }
 
             it("returns an expected contentEdgeInsets") {
-                let spacing = getTheme().spacing.small
+                let spacing: CGFloat = 12
 
                 expect(button.contentEdgeInsets.top).to(equal(spacing))
                 expect(button.contentEdgeInsets.right).to(equal(spacing))
@@ -116,7 +116,7 @@ final class ButtonTextStyleSpec: QuickSpec {
                     let foregroundColor = attributes[.foregroundColor] as? UIColor
 
                     expect(foregroundColor)
-                        .to(equal(NatColors.onSurface.withAlphaComponent(getTheme().opacities.opacity06)))
+                        .to(equal(NatColors.onSurface.withAlphaComponent(getTheme().opacities.opacity08)))
                 }
             }
         }

--- a/Tests/Public/Components/Button/NatButton+EdgeInsets+Spec.swift
+++ b/Tests/Public/Components/Button/NatButton+EdgeInsets+Spec.swift
@@ -3,7 +3,7 @@ import Nimble
 
 @testable import NatDS
 
-final class NatButtonEdgeInsetstSpec: QuickSpec {
+final class NatButtonEdgeInsetsSpec: QuickSpec {
     override func spec() {
         let systemUnderTest = NatButton.EdgeInsets.self
 

--- a/Tests/Public/Components/Button/NatButton+EdgeInsets+Spec.swift
+++ b/Tests/Public/Components/Button/NatButton+EdgeInsets+Spec.swift
@@ -1,0 +1,32 @@
+import Quick
+import Nimble
+
+@testable import NatDS
+
+final class NatButtonEdgeInsetstSpec: QuickSpec {
+    override func spec() {
+        let systemUnderTest = NatButton.EdgeInsets.self
+
+        beforeEach {
+            DesignSystem().configure(with: .theBodyShop)
+        }
+
+        describe("#small") {
+            it("returns expected edgeInsets") {
+                expect(systemUnderTest.small).to(equal(.init(top: 8, left: 8, bottom: 8, right: 8)))
+            }
+        }
+
+        describe("#medium") {
+            it("returns expected edgeInsets") {
+                expect(systemUnderTest.medium).to(equal(.init(top: 12, left: 12, bottom: 12, right: 12)))
+            }
+        }
+
+        describe("#large") {
+            it("returns expected edgeInsets") {
+                expect(systemUnderTest.large).to(equal(.init(top: 16, left: 16, bottom: 16, right: 16)))
+            }
+        }
+    }
+}

--- a/Tests/ReferenceImages_64/NatDSTests.NatDialogControllerSnapshotTests/test_dialog_style_standard_hasValidSnapshot@2x.png
+++ b/Tests/ReferenceImages_64/NatDSTests.NatDialogControllerSnapshotTests/test_dialog_style_standard_hasValidSnapshot@2x.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:57d8d5d1651942a30474744a205b8eaf47f9b12db3707b73ca03937754e763c8
-size 46397
+oid sha256:d2e2aa62a8f672d168fb02fb795fccfa50edebe9e31fa0bd6788b064a79f4a84
+size 46394

--- a/Tests/ReferenceImages_64/NatDSTests.NatDialogControllerSnapshotTests/test_dialog_style_standard_with_vertical_buttons_hasValidSnapshot@2x.png
+++ b/Tests/ReferenceImages_64/NatDSTests.NatDialogControllerSnapshotTests/test_dialog_style_standard_with_vertical_buttons_hasValidSnapshot@2x.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:54ad6d6bcd89723e476e4eed7cb5d4fb4b209cbc70e9cfb289e7a697b0c0f7df
-size 49381
+oid sha256:a7a1db2e6ab44d95bae101c1ae604124e3da432e518343777f257ce594bf040b
+size 49379


### PR DESCRIPTION
# Description

- Adds pre set values to NatButton content edge insets (small, medium, large)
- Design changes: Colors for NatButton state `Disable`, to better for accessibility.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
