### PR TITLE
chore: add "enum" to safelist to .typo-ci.yml

### DIFF
--- a/.typo-ci.yml
+++ b/.typo-ci.yml
@@ -5,6 +5,7 @@ excluded_files:
   - "NatDS.xcodeproj/project.pbxproj"
   - "SampleApp/NatDS-SampleApp.xcodeproj/project.pbxproj"
 excluded_words:
+  - enum
   - Inits
   - isa
   - nat


### PR DESCRIPTION
# Description

This PR adds the word `enum` to Typo CI safelist

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [X] Internal change (chore)
