### PR TITLE
[DSY-1459] refactor: 💡 Removes suffix from protocol theme and elements

### DIFF
--- a/NatDS.xcodeproj/project.pbxproj
+++ b/NatDS.xcodeproj/project.pbxproj
@@ -125,7 +125,7 @@
 		848831BE25018340004C3FA8 /* NatIconButton+Styles.swift in Sources */ = {isa = PBXBuildFile; fileRef = 848831BD25018340004C3FA8 /* NatIconButton+Styles.swift */; };
 		84932F1324EAB9270052265F /* AvailableTheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84932F1224EAB9270052265F /* AvailableTheme.swift */; };
 		84932F1624EABB190052265F /* AvailableTheme+Spec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84932F1424EABA280052265F /* AvailableTheme+Spec.swift */; };
-		84932F1A24EAF07B0052265F /* StubThemeProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84932F1824EAF06B0052265F /* StubThemeProtocol.swift */; };
+		84932F1A24EAF07B0052265F /* StubTheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84932F1824EAF06B0052265F /* StubTheme.swift */; };
 		84A16EFF24DDBC6D00E80DA0 /* NavigationDrawerItemCell+Snapshot+Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84A16EFE24DDBC6D00E80DA0 /* NavigationDrawerItemCell+Snapshot+Tests.swift */; };
 		84A16F0124DDBE5500E80DA0 /* NavigationDrawerSubitemCell+Snapshot+Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84A16F0024DDBE5500E80DA0 /* NavigationDrawerSubitemCell+Snapshot+Tests.swift */; };
 		84A16F0324DDBF6C00E80DA0 /* NavigationDrawer+Snapshot+Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84A16F0224DDBF6C00E80DA0 /* NavigationDrawer+Snapshot+Tests.swift */; };
@@ -367,7 +367,7 @@
 		848831BD25018340004C3FA8 /* NatIconButton+Styles.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NatIconButton+Styles.swift"; sourceTree = "<group>"; };
 		84932F1224EAB9270052265F /* AvailableTheme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AvailableTheme.swift; sourceTree = "<group>"; };
 		84932F1424EABA280052265F /* AvailableTheme+Spec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AvailableTheme+Spec.swift"; sourceTree = "<group>"; };
-		84932F1824EAF06B0052265F /* StubThemeProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StubThemeProtocol.swift; sourceTree = "<group>"; };
+		84932F1824EAF06B0052265F /* StubTheme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StubTheme.swift; sourceTree = "<group>"; };
 		84A16EFE24DDBC6D00E80DA0 /* NavigationDrawerItemCell+Snapshot+Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NavigationDrawerItemCell+Snapshot+Tests.swift"; sourceTree = "<group>"; };
 		84A16F0024DDBE5500E80DA0 /* NavigationDrawerSubitemCell+Snapshot+Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NavigationDrawerSubitemCell+Snapshot+Tests.swift"; sourceTree = "<group>"; };
 		84A16F0224DDBF6C00E80DA0 /* NavigationDrawer+Snapshot+Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NavigationDrawer+Snapshot+Tests.swift"; sourceTree = "<group>"; };
@@ -1136,7 +1136,7 @@
 		84932F1724EAF0510052265F /* Theme */ = {
 			isa = PBXGroup;
 			children = (
-				84932F1824EAF06B0052265F /* StubThemeProtocol.swift */,
+				84932F1824EAF06B0052265F /* StubTheme.swift */,
 			);
 			path = Theme;
 			sourceTree = "<group>";
@@ -1993,7 +1993,7 @@
 				AA1F5760B92801C89E927B323F7691B7 /* NatButton+Height+Spec.swift in Sources */,
 				19CCAA043E9657B0F68877ABC0F7F90F /* NatButton+Specs.swift in Sources */,
 				84BF066B24B504B200462AC5 /* ShortcutOutlinedStyle+Spec.swift in Sources */,
-				84932F1A24EAF07B0052265F /* StubThemeProtocol.swift in Sources */,
+				84932F1A24EAF07B0052265F /* StubTheme.swift in Sources */,
 				D18DCEC54B0D407538EC7F218CDF25E1 /* NatColors+Spec.swift in Sources */,
 				C4EB3DDBDD3DEFDA5183455CCDB2720F /* NatDialogController+Spec.swift in Sources */,
 				E891D4E704EDCC6EA9CD3EE125A5D292 /* NatDialogController+StandardStyleBuilder+Spec.swift in Sources */,

--- a/NatDS.xcodeproj/project.pbxproj
+++ b/NatDS.xcodeproj/project.pbxproj
@@ -99,7 +99,7 @@
 		84391DEA24DB477F009D0BE8 /* NatShortcut+Snapshot+Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84A818BC24B784EA0007C7D5 /* NatShortcut+Snapshot+Tests.swift */; };
 		84391DED24DB5C1F009D0BE8 /* AppBar+Snapshot+Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 268E9C6024C8746B006D6142 /* AppBar+Snapshot+Tests.swift */; };
 		844A1E2324AE117400E93AD9 /* NatShortcut.swift in Sources */ = {isa = PBXBuildFile; fileRef = 844A1E2224AE117400E93AD9 /* NatShortcut.swift */; };
-		845AD7A424E2C4DA006CA226 /* ThemeProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 845AD7A324E2C4DA006CA226 /* ThemeProtocol.swift */; };
+		845AD7A424E2C4DA006CA226 /* Theme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 845AD7A324E2C4DA006CA226 /* Theme.swift */; };
 		845AD7A824E2C8E6006CA226 /* AvonDarkTheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 845AD7A724E2C8E6006CA226 /* AvonDarkTheme.swift */; };
 		845AD7AA24E2CC82006CA226 /* AvonLightTheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 845AD7A924E2CC82006CA226 /* AvonLightTheme.swift */; };
 		845D09952501193500B05760 /* NatIconButton+Sizes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 845D09942501193500B05760 /* NatIconButton+Sizes.swift */; };
@@ -342,7 +342,7 @@
 		84391DDD24DB1B8B009D0BE8 /* NatDSSnapShotTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = NatDSSnapShotTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		84391DE124DB1B8B009D0BE8 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		844A1E2224AE117400E93AD9 /* NatShortcut.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NatShortcut.swift; sourceTree = "<group>"; };
-		845AD7A324E2C4DA006CA226 /* ThemeProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemeProtocol.swift; sourceTree = "<group>"; };
+		845AD7A324E2C4DA006CA226 /* Theme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Theme.swift; sourceTree = "<group>"; };
 		845AD7A724E2C8E6006CA226 /* AvonDarkTheme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AvonDarkTheme.swift; sourceTree = "<group>"; };
 		845AD7A924E2CC82006CA226 /* AvonLightTheme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AvonLightTheme.swift; sourceTree = "<group>"; };
 		845D09942501193500B05760 /* NatIconButton+Sizes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NatIconButton+Sizes.swift"; sourceTree = "<group>"; };
@@ -957,7 +957,7 @@
 			isa = PBXGroup;
 			children = (
 				847C829724E562B4001CE116 /* DeprecatedWillBeRemoved */,
-				845AD7A324E2C4DA006CA226 /* ThemeProtocol.swift */,
+				845AD7A324E2C4DA006CA226 /* Theme.swift */,
 				845AD7A524E2C8C5006CA226 /* BrandsThemes */,
 			);
 			path = SingleSourceOfTruth;
@@ -1133,12 +1133,12 @@
 			path = TheBodyShop;
 			sourceTree = "<group>";
 		};
-		84932F1724EAF0510052265F /* ThemeProtocol */ = {
+		84932F1724EAF0510052265F /* Theme */ = {
 			isa = PBXGroup;
 			children = (
 				84932F1824EAF06B0052265F /* StubThemeProtocol.swift */,
 			);
-			path = ThemeProtocol;
+			path = Theme;
 			sourceTree = "<group>";
 		};
 		84A16EFD24DDBC3200E80DA0 /* NavigationDrawer */ = {
@@ -1515,7 +1515,7 @@
 		B74C0772E6C10FAF9E1EBEDD82A7F0B1 /* TestingHelpers */ = {
 			isa = PBXGroup;
 			children = (
-				84932F1724EAF0510052265F /* ThemeProtocol */,
+				84932F1724EAF0510052265F /* Theme */,
 				58907D6C652303C4D5FC5FFE6E8F721A /* ElevationAttributes+Equitable.swift */,
 				255B7772A418A4544E0B8F793BEB519D /* UIColor+AsHexString.swift */,
 				56F3D70C29CCB183081E1863D791C9D4 /* UIFont+GetWeight.swift */,
@@ -2080,7 +2080,7 @@
 				98C6EB095DD059D51DD9883B943AF889 /* ButtonOutlineStyle.swift in Sources */,
 				14016A20C7BF7046BAFCD2AE53673EB0 /* ButtonStyle.swift in Sources */,
 				84EB6B8524EEEA8E00C6A792 /* GetOrCreatedCachedColor.swift in Sources */,
-				845AD7A424E2C4DA006CA226 /* ThemeProtocol.swift in Sources */,
+				845AD7A424E2C4DA006CA226 /* Theme.swift in Sources */,
 				000598F48ADE170D305737C11E3F2D99 /* ButtonTextStyle.swift in Sources */,
 				845D09952501193500B05760 /* NatIconButton+Sizes.swift in Sources */,
 				845AD7AA24E2CC82006CA226 /* AvonLightTheme.swift in Sources */,

--- a/Sources/Core/DataSource/ConfigurationStorage.swift
+++ b/Sources/Core/DataSource/ConfigurationStorage.swift
@@ -1,5 +1,5 @@
 final class ConfigurationStorage {
-    var currentTheme: ThemeProtocol?
+    var currentTheme: Theme?
     var cachedColors: [String: UIColor] = [:]
 
     private init() {}

--- a/Sources/Core/DomainFunctions/GetComponentFromTheme.swift
+++ b/Sources/Core/DomainFunctions/GetComponentFromTheme.swift
@@ -1,4 +1,4 @@
-func getComponentAttributeFromTheme<T>(_ keyPath: KeyPath<ComponentsProtocol, T>) -> T {
+func getComponentAttributeFromTheme<T>(_ keyPath: KeyPath<Components, T>) -> T {
     getThemeValidated(
         from: ConfigurationStorage.shared,
         fatalError: designSystemFatalError

--- a/Sources/Core/DomainFunctions/GetThemeValidated.swift
+++ b/Sources/Core/DomainFunctions/GetThemeValidated.swift
@@ -1,6 +1,6 @@
 func getThemeValidated(
     from storage: ConfigurationStorage,
-    fatalError: () -> Never) -> ThemeProtocol {
+    fatalError: () -> Never) -> Theme {
 
     guard let theme = storage.currentTheme else { fatalError() }
 

--- a/Sources/Core/DomainFunctions/GetTokensFromTheme.swift
+++ b/Sources/Core/DomainFunctions/GetTokensFromTheme.swift
@@ -1,4 +1,4 @@
-func getTokenFromTheme<T>(_ keyPath: KeyPath<TokensProtocol, T>) -> T {
+func getTokenFromTheme<T>(_ keyPath: KeyPath<Tokens, T>) -> T {
     getThemeValidated(
         from: ConfigurationStorage.shared,
         fatalError: designSystemFatalError

--- a/Sources/Core/DomainFunctions/GetUIColorFromTokens.swift
+++ b/Sources/Core/DomainFunctions/GetUIColorFromTokens.swift
@@ -1,4 +1,4 @@
-func getUIColorFromTokens(_ keyPath: KeyPath<TokensProtocol, String>) -> UIColor {
+func getUIColorFromTokens(_ keyPath: KeyPath<Tokens, String>) -> UIColor {
     getOrCreatedCachedColor(
         colorHex: getTokenFromTheme(keyPath),
         storage: ConfigurationStorage.shared,

--- a/Sources/Core/Theme/Elevations.swift
+++ b/Sources/Core/Theme/Elevations.swift
@@ -1,4 +1,4 @@
-extension TokensProtocol {
+extension Tokens {
     var elevationNone: ElevationAttributes {
         .init(
             shadowColor: nil,

--- a/Sources/Core/Theme/SingleSourceOfTruth/BrandsThemes/Avon/AvonDarkTheme.swift
+++ b/Sources/Core/Theme/SingleSourceOfTruth/BrandsThemes/Avon/AvonDarkTheme.swift
@@ -17,12 +17,12 @@
  *
  */
 
-struct AvonDarkTheme: ThemeProtocol {
-    let tokens: TokensProtocol = AvonDarkTokens()
-    let components: ComponentsProtocol = AvonDarkComponents()
+struct AvonDarkTheme: Theme {
+    let tokens: Tokens = AvonDarkTokens()
+    let components: Components = AvonDarkComponents()
 }
 
-struct AvonDarkTokens: TokensProtocol {
+struct AvonDarkTokens: Tokens {
     let borderRadiusNone: CGFloat = 0
     let borderRadiusSmall: CGFloat = 2
     let borderRadiusMedium: CGFloat = 4
@@ -92,7 +92,7 @@ struct AvonDarkTokens: TokensProtocol {
     let typographyFontWeightMedium: UIFont.Weight = .medium
 }
 
-struct AvonDarkComponents: ComponentsProtocol {
+struct AvonDarkComponents: Components {
     let buttonDefaultFontSize: CGFloat = 14
     let buttonDefaultFontWeight: UIFont.Weight = .medium
     let buttonDefaultLetterSpacing: CGFloat = 0.44

--- a/Sources/Core/Theme/SingleSourceOfTruth/BrandsThemes/Avon/AvonLightTheme.swift
+++ b/Sources/Core/Theme/SingleSourceOfTruth/BrandsThemes/Avon/AvonLightTheme.swift
@@ -17,12 +17,12 @@
  *
  */
 
-struct AvonLightTheme: ThemeProtocol {
-    let tokens: TokensProtocol = AvonLightTokens()
-    let components: ComponentsProtocol = AvonLightComponents()
+struct AvonLightTheme: Theme {
+    let tokens: Tokens = AvonLightTokens()
+    let components: Components = AvonLightComponents()
 }
 
-struct AvonLightTokens: TokensProtocol {
+struct AvonLightTokens: Tokens {
     let borderRadiusNone: CGFloat = 0
     let borderRadiusSmall: CGFloat = 2
     let borderRadiusMedium: CGFloat = 4
@@ -92,7 +92,7 @@ struct AvonLightTokens: TokensProtocol {
     let typographyFontWeightMedium: UIFont.Weight = .medium
 }
 
-struct AvonLightComponents: ComponentsProtocol {
+struct AvonLightComponents: Components {
     let buttonDefaultFontSize: CGFloat = 14
     let buttonDefaultFontWeight: UIFont.Weight = .medium
     let buttonDefaultLetterSpacing: CGFloat = 0.44

--- a/Sources/Core/Theme/SingleSourceOfTruth/BrandsThemes/Natura/NaturaDarkTheme.swift
+++ b/Sources/Core/Theme/SingleSourceOfTruth/BrandsThemes/Natura/NaturaDarkTheme.swift
@@ -17,12 +17,12 @@
  *
  */
 
-struct NaturaDarkTheme: ThemeProtocol {
-    let tokens: TokensProtocol = NaturaDarkTokens()
-    let components: ComponentsProtocol = NaturaDarkComponents()
+struct NaturaDarkTheme: Theme {
+    let tokens: Tokens = NaturaDarkTokens()
+    let components: Components = NaturaDarkComponents()
 }
 
-struct NaturaDarkTokens: TokensProtocol {
+struct NaturaDarkTokens: Tokens {
     let borderRadiusNone: CGFloat = 0
     let borderRadiusSmall: CGFloat = 2
     let borderRadiusMedium: CGFloat = 4
@@ -92,7 +92,7 @@ struct NaturaDarkTokens: TokensProtocol {
     let typographyFontWeightMedium: UIFont.Weight = .medium
 }
 
-struct NaturaDarkComponents: ComponentsProtocol {
+struct NaturaDarkComponents: Components {
     let buttonDefaultFontSize: CGFloat = 14
     let buttonDefaultFontWeight: UIFont.Weight = .medium
     let buttonDefaultLetterSpacing: CGFloat = 0.44

--- a/Sources/Core/Theme/SingleSourceOfTruth/BrandsThemes/Natura/NaturaLightTheme.swift
+++ b/Sources/Core/Theme/SingleSourceOfTruth/BrandsThemes/Natura/NaturaLightTheme.swift
@@ -17,12 +17,12 @@
  *
  */
 
-struct NaturaLightTheme: ThemeProtocol {
-    let tokens: TokensProtocol = NaturaLightTokens()
-    let components: ComponentsProtocol = NaturaLightComponents()
+struct NaturaLightTheme: Theme {
+    let tokens: Tokens = NaturaLightTokens()
+    let components: Components = NaturaLightComponents()
 }
 
-struct NaturaLightTokens: TokensProtocol {
+struct NaturaLightTokens: Tokens {
     let borderRadiusNone: CGFloat = 0
     let borderRadiusSmall: CGFloat = 2
     let borderRadiusMedium: CGFloat = 4
@@ -92,7 +92,7 @@ struct NaturaLightTokens: TokensProtocol {
     let typographyFontWeightMedium: UIFont.Weight = .medium
 }
 
-struct NaturaLightComponents: ComponentsProtocol {
+struct NaturaLightComponents: Components {
     let buttonDefaultFontSize: CGFloat = 14
     let buttonDefaultFontWeight: UIFont.Weight = .medium
     let buttonDefaultLetterSpacing: CGFloat = 0.44

--- a/Sources/Core/Theme/SingleSourceOfTruth/BrandsThemes/TheBodyShop/TheBodyShopDarkTheme.swift
+++ b/Sources/Core/Theme/SingleSourceOfTruth/BrandsThemes/TheBodyShop/TheBodyShopDarkTheme.swift
@@ -17,12 +17,12 @@
  *
  */
 
-struct TheBodyShopDarkTheme: ThemeProtocol {
-    let tokens: TokensProtocol = TheBodyShopDarkTokens()
-    let components: ComponentsProtocol = TheBodyShopDarkComponents()
+struct TheBodyShopDarkTheme: Theme {
+    let tokens: Tokens = TheBodyShopDarkTokens()
+    let components: Components = TheBodyShopDarkComponents()
 }
 
-struct TheBodyShopDarkTokens: TokensProtocol {
+struct TheBodyShopDarkTokens: Tokens {
     let borderRadiusNone: CGFloat = 0
     let borderRadiusSmall: CGFloat = 2
     let borderRadiusMedium: CGFloat = 4
@@ -92,7 +92,7 @@ struct TheBodyShopDarkTokens: TokensProtocol {
     let typographyFontWeightMedium: UIFont.Weight = .medium
 }
 
-struct TheBodyShopDarkComponents: ComponentsProtocol {
+struct TheBodyShopDarkComponents: Components {
     let buttonDefaultFontSize: CGFloat = 14
     let buttonDefaultFontWeight: UIFont.Weight = .medium
     let buttonDefaultLetterSpacing: CGFloat = 0.44

--- a/Sources/Core/Theme/SingleSourceOfTruth/BrandsThemes/TheBodyShop/TheBodyShopLightTheme.swift
+++ b/Sources/Core/Theme/SingleSourceOfTruth/BrandsThemes/TheBodyShop/TheBodyShopLightTheme.swift
@@ -17,12 +17,12 @@
  *
  */
 
-struct TheBodyShopLightTheme: ThemeProtocol {
-    let tokens: TokensProtocol = TheBodyShopLightTokens()
-    let components: ComponentsProtocol = TheBodyShopLightComponents()
+struct TheBodyShopLightTheme: Theme {
+    let tokens: Tokens = TheBodyShopLightTokens()
+    let components: Components = TheBodyShopLightComponents()
 }
 
-struct TheBodyShopLightTokens: TokensProtocol {
+struct TheBodyShopLightTokens: Tokens {
     let borderRadiusNone: CGFloat = 0
     let borderRadiusSmall: CGFloat = 2
     let borderRadiusMedium: CGFloat = 4
@@ -92,7 +92,7 @@ struct TheBodyShopLightTokens: TokensProtocol {
     let typographyFontWeightMedium: UIFont.Weight = .medium
 }
 
-struct TheBodyShopLightComponents: ComponentsProtocol {
+struct TheBodyShopLightComponents: Components {
     let buttonDefaultFontSize: CGFloat = 14
     let buttonDefaultFontWeight: UIFont.Weight = .medium
     let buttonDefaultLetterSpacing: CGFloat = 0.44

--- a/Sources/Core/Theme/SingleSourceOfTruth/Theme.swift
+++ b/Sources/Core/Theme/SingleSourceOfTruth/Theme.swift
@@ -17,12 +17,12 @@
  *
  */
 
-protocol ThemeProtocol {
-    var tokens: TokensProtocol { get }
-    var components: ComponentsProtocol { get }
+protocol Theme {
+    var tokens: Tokens { get }
+    var components: Components { get }
 }
 
-protocol TokensProtocol {
+protocol Tokens {
     var borderRadiusNone: CGFloat { get }
     var borderRadiusSmall: CGFloat { get }
     var borderRadiusMedium: CGFloat { get }
@@ -115,7 +115,7 @@ protocol TokensProtocol {
     var elevation10: ElevationAttributes { get }
 }
 
-protocol ComponentsProtocol {
+protocol Components {
     var buttonDefaultFontSize: CGFloat { get }
     var buttonDefaultFontWeight: UIFont.Weight { get }
     var buttonDefaultLetterSpacing: CGFloat { get }

--- a/Sources/Core/Theme/Theme+Opacities.swift
+++ b/Sources/Core/Theme/Theme+Opacities.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-extension TokensProtocol {
+extension Tokens {
     var opacityTransparent: CGFloat { 0 }
     var opacity01: CGFloat { 0.04 }
     var opacity02: CGFloat { 0.08 }

--- a/Sources/Public/AvailableTheme.swift
+++ b/Sources/Public/AvailableTheme.swift
@@ -19,7 +19,7 @@ public enum AvailableTheme {
     case theBodyShopDark
     case theBodyShopLight
 
-    init?(theme: ThemeProtocol) {
+    init?(theme: Theme) {
         switch theme {
         case is AvonDarkTheme: self = .avonDark
         case is AvonLightTheme: self = .avonLight
@@ -31,8 +31,8 @@ public enum AvailableTheme {
         }
     }
 
-    var newInstance: ThemeProtocol {
-        let instance: ThemeProtocol
+    var newInstance: Theme {
+        let instance: Theme
 
         switch self {
         case .avonDark: instance = AvonDarkTheme()

--- a/Sources/Public/DesignTokens/NatElevation.swift
+++ b/Sources/Public/DesignTokens/NatElevation.swift
@@ -35,8 +35,8 @@ extension NatElevation {
         case elevation09
         case elevation10
 
-        var rawValue: KeyPath<TokensProtocol, ElevationAttributes> {
-            let keyPath: KeyPath<TokensProtocol, ElevationAttributes>
+        var rawValue: KeyPath<Tokens, ElevationAttributes> {
+            let keyPath: KeyPath<Tokens, ElevationAttributes>
 
             switch self {
             case .none: keyPath = \.elevationNone

--- a/Tests/Core/DomainFunctions/GetOrCreatedCachedColor+Spec.swift
+++ b/Tests/Core/DomainFunctions/GetOrCreatedCachedColor+Spec.swift
@@ -27,7 +27,7 @@ final class GetOrCreatedCachedColorSpec: QuickSpec {
             var color: UIColor?
 
             beforeEach {
-                ConfigurationStorage.shared.currentTheme = StubThemeProtocol()
+                ConfigurationStorage.shared.currentTheme = StubTheme()
                 color = systemUnderTest("#000000", store, { fatalError("stub error") })
             }
 
@@ -45,7 +45,7 @@ final class GetOrCreatedCachedColorSpec: QuickSpec {
 
             beforeEach {
                 store.cachedColors["#FFFFFF"] = .white
-                store.currentTheme = StubThemeProtocol()
+                store.currentTheme = StubTheme()
                 color = systemUnderTest("#000000", store, { fatalError("stub error") })
             }
 

--- a/Tests/Core/DomainFunctions/GetThemeValidated+Spec.swift
+++ b/Tests/Core/DomainFunctions/GetThemeValidated+Spec.swift
@@ -23,7 +23,7 @@ final class GetThemeValidatedSpec: QuickSpec {
 
         context("when some theme is stored") {
             it("returns a expect value") {
-                ConfigurationStorage.shared.currentTheme = StubThemeProtocol()
+                ConfigurationStorage.shared.currentTheme = StubTheme()
                 let theme = systemUnderTest(ConfigurationStorage.shared, designSystemFatalError)
 
                 expect(theme).toNot(beNil())

--- a/Tests/Core/Extensions/NSMutableAttributedString+BuilderTests.swift
+++ b/Tests/Core/Extensions/NSMutableAttributedString+BuilderTests.swift
@@ -11,7 +11,7 @@ class NSMutableAttributedStringBuilderTests: XCTestCase {
         string = "Lorem ipsum dolor sit amet."
         substring = "ipsum"
 
-        ConfigurationStorage.shared.currentTheme = StubThemeProtocol()
+        ConfigurationStorage.shared.currentTheme = StubTheme()
     }
 
     func test_applyFont_returnsAttributedStringWithAppliedFont() {

--- a/Tests/Core/ViewStyle/Button/ButtonContainedStyle+Spec.swift
+++ b/Tests/Core/ViewStyle/Button/ButtonContainedStyle+Spec.swift
@@ -9,7 +9,7 @@ final class ButtonContainedStyleSpec: QuickSpec {
         var button: UIButton!
 
         beforeEach {
-            ConfigurationStorage.shared.currentTheme = StubThemeProtocol()
+            ConfigurationStorage.shared.currentTheme = StubTheme()
 
             button = UIButton()
         }

--- a/Tests/Core/ViewStyle/Button/ButtonOutlinedStyle+Spec.swift
+++ b/Tests/Core/ViewStyle/Button/ButtonOutlinedStyle+Spec.swift
@@ -9,7 +9,7 @@ final class ButtonOutlinedStyleSpec: QuickSpec {
         var button: UIButton!
 
         beforeEach {
-            ConfigurationStorage.shared.currentTheme = StubThemeProtocol()
+            ConfigurationStorage.shared.currentTheme = StubTheme()
 
             button = UIButton()
         }

--- a/Tests/Core/ViewStyle/Button/ButtonStyle+Spec.swift
+++ b/Tests/Core/ViewStyle/Button/ButtonStyle+Spec.swift
@@ -9,7 +9,7 @@ final class ButtonStyleSpec: QuickSpec {
         var button: UIButton!
 
         beforeEach {
-            ConfigurationStorage.shared.currentTheme = StubThemeProtocol()
+            ConfigurationStorage.shared.currentTheme = StubTheme()
 
             button = UIButton()
         }

--- a/Tests/Core/ViewStyle/Button/ButtonTextStyle+Spec.swift
+++ b/Tests/Core/ViewStyle/Button/ButtonTextStyle+Spec.swift
@@ -9,7 +9,7 @@ final class ButtonTextStyleSpec: QuickSpec {
         var button: UIButton!
 
         beforeEach {
-            ConfigurationStorage.shared.currentTheme = StubThemeProtocol()
+            ConfigurationStorage.shared.currentTheme = StubTheme()
 
             button = UIButton()
         }

--- a/Tests/Core/ViewStyle/Dialog/DialogFooterView+Spec.swift
+++ b/Tests/Core/ViewStyle/Dialog/DialogFooterView+Spec.swift
@@ -9,7 +9,7 @@ final class DialogFooterViewSpec: QuickSpec {
         var notificationCenterSpy: NotificationCenterSpy!
 
         beforeEach {
-            ConfigurationStorage.shared.currentTheme = StubThemeProtocol()
+            ConfigurationStorage.shared.currentTheme = StubTheme()
 
             notificationCenterSpy = .init()
             systemUnderTest = .init(notificationCenter: notificationCenterSpy)

--- a/Tests/Core/ViewStyle/Dialog/DialogStyle+Spec.swift
+++ b/Tests/Core/ViewStyle/Dialog/DialogStyle+Spec.swift
@@ -8,7 +8,7 @@ final class DialogStyleSpec: QuickSpec {
         let systemUnderTest = DialogStyle.self
 
         beforeEach {
-            ConfigurationStorage.shared.currentTheme = StubThemeProtocol()
+            ConfigurationStorage.shared.currentTheme = StubTheme()
         }
 
         describe("#createLabelForTitle") {

--- a/Tests/Core/ViewStyle/IconButton/IconButtonStandardStyle+Spec.swift
+++ b/Tests/Core/ViewStyle/IconButton/IconButtonStandardStyle+Spec.swift
@@ -11,7 +11,7 @@ final class IconButtonStandardStyleSpec: QuickSpec {
         var iconView: IconView!
 
         beforeEach {
-            ConfigurationStorage.shared.currentTheme = StubThemeProtocol()
+            ConfigurationStorage.shared.currentTheme = StubTheme()
 
             iconButton = NatIconButton(style: stubStyle)
             iconView = iconButton.subviews.first as? IconView

--- a/Tests/Core/ViewStyle/Shortcut/ShortcutContainedStyle+Spec.swift
+++ b/Tests/Core/ViewStyle/Shortcut/ShortcutContainedStyle+Spec.swift
@@ -11,7 +11,7 @@ final class ShortcutContainedStyleSpec: QuickSpec {
         var circleView: UIView!
 
         beforeEach {
-            ConfigurationStorage.shared.currentTheme = StubThemeProtocol()
+            ConfigurationStorage.shared.currentTheme = StubTheme()
 
             shortcut = NatShortcut(style: stubStyle)
             circleView = shortcut.subviews.first

--- a/Tests/Core/ViewStyle/Shortcut/ShortcutOutlinedStyle+Spec.swift
+++ b/Tests/Core/ViewStyle/Shortcut/ShortcutOutlinedStyle+Spec.swift
@@ -11,7 +11,7 @@ final class ShortcutOutlinedStyleSpec: QuickSpec {
         var circleView: UIView!
 
         beforeEach {
-            ConfigurationStorage.shared.currentTheme = StubThemeProtocol()
+            ConfigurationStorage.shared.currentTheme = StubTheme()
 
             shortcut = NatShortcut(style: stubStyle)
             circleView = shortcut.subviews.first

--- a/Tests/Public/AvailableTheme+Spec.swift
+++ b/Tests/Public/AvailableTheme+Spec.swift
@@ -45,7 +45,7 @@ final class AvailableThemeSpec: QuickSpec {
             }
 
             it("initializes with expected value") {
-                let availableTheme = systemUnderTest.init(theme: StubThemeProtocol())
+                let availableTheme = systemUnderTest.init(theme: StubTheme())
 
                 expect(availableTheme).to(beNil())
             }

--- a/Tests/Public/Components/AppBar/UIBarButtonItem+Icon+Spec.swift
+++ b/Tests/Public/Components/AppBar/UIBarButtonItem+Icon+Spec.swift
@@ -9,7 +9,7 @@ final class UIBarButtonItemIconSpec: QuickSpec {
         var sut: UIBarButtonItem!
 
         beforeEach {
-            ConfigurationStorage.shared.currentTheme = StubThemeProtocol()
+            ConfigurationStorage.shared.currentTheme = StubTheme()
             selector = StubSelector()
 
             sut = UIBarButtonItem(icon: Icon.filledActionAdd, action: #selector(selector.handler), target: selector)

--- a/Tests/Public/Components/AppBar/UINavigationController+Configure+Spec.swift
+++ b/Tests/Public/Components/AppBar/UINavigationController+Configure+Spec.swift
@@ -9,7 +9,7 @@ final class UINavigationControllerConfigureSpec: QuickSpec {
         var style: UINavigationController.Style!
 
         beforeEach {
-            ConfigurationStorage.shared.currentTheme = StubThemeProtocol()
+            ConfigurationStorage.shared.currentTheme = StubTheme()
 
             sut = UINavigationController()
             style = .default

--- a/Tests/Public/Components/AppBar/UINavigationController+Style+Spec.swift
+++ b/Tests/Public/Components/AppBar/UINavigationController+Style+Spec.swift
@@ -8,7 +8,7 @@ final class UINavigationControllerStyleSpec: QuickSpec {
         var sut: UINavigationController.Style!
 
         beforeEach {
-            ConfigurationStorage.shared.currentTheme = StubThemeProtocol()
+            ConfigurationStorage.shared.currentTheme = StubTheme()
         }
 
         describe("#default") {

--- a/Tests/Public/Components/Badge/NatBadge+Color+Spec.swift
+++ b/Tests/Public/Components/Badge/NatBadge+Color+Spec.swift
@@ -8,7 +8,7 @@ final class NatBadgeColorSpec: QuickSpec {
         let systemUnderTest = NatBadge.Color.self
 
         beforeEach {
-            ConfigurationStorage.shared.currentTheme = StubThemeProtocol()
+            ConfigurationStorage.shared.currentTheme = StubTheme()
         }
 
         describe("#alert") {

--- a/Tests/Public/Components/Badge/NatBadge+Spec.swift
+++ b/Tests/Public/Components/Badge/NatBadge+Spec.swift
@@ -8,7 +8,7 @@ final class NatBadgeSpec: QuickSpec {
         var systemUnderTest: NatBadge!
 
         beforeEach {
-            ConfigurationStorage.shared.currentTheme = StubThemeProtocol()
+            ConfigurationStorage.shared.currentTheme = StubTheme()
 
             systemUnderTest = NatBadge(style: .standard, color: .alert)
         }

--- a/Tests/Public/Components/Badge/Protocol/Badgeable+Spec.swift
+++ b/Tests/Public/Components/Badge/Protocol/Badgeable+Spec.swift
@@ -8,7 +8,7 @@ final class BadgeableSpec: QuickSpec {
         var systemUnderTest: Badgeable!
 
         beforeEach {
-            ConfigurationStorage.shared.currentTheme = StubThemeProtocol()
+            ConfigurationStorage.shared.currentTheme = StubTheme()
 
             systemUnderTest = BadgeableStub()
         }

--- a/Tests/Public/Components/Button/NatButton+EdgeInsets+Spec.swift
+++ b/Tests/Public/Components/Button/NatButton+EdgeInsets+Spec.swift
@@ -8,7 +8,7 @@ final class NatButtonEdgeInsetsSpec: QuickSpec {
         let systemUnderTest = NatButton.EdgeInsets.self
 
         beforeEach {
-            ConfigurationStorage.shared.currentTheme = StubThemeProtocol()
+            ConfigurationStorage.shared.currentTheme = StubTheme()
         }
 
         describe("#small") {

--- a/Tests/Public/Components/Button/NatButton+Height+Spec.swift
+++ b/Tests/Public/Components/Button/NatButton+Height+Spec.swift
@@ -8,7 +8,7 @@ final class NatButtonHeightSpec: QuickSpec {
         let systemUnderTest = NatButton.Height.self
 
         beforeEach {
-            ConfigurationStorage.shared.currentTheme = StubThemeProtocol()
+            ConfigurationStorage.shared.currentTheme = StubTheme()
         }
 
         describe("#small") {

--- a/Tests/Public/Components/Button/NatButton+Specs.swift
+++ b/Tests/Public/Components/Button/NatButton+Specs.swift
@@ -16,7 +16,7 @@ final class NatButtonSpec: QuickSpec {
         var styleSpy: NatButton.Style!
 
         beforeEach {
-            ConfigurationStorage.shared.currentTheme = StubThemeProtocol()
+            ConfigurationStorage.shared.currentTheme = StubTheme()
 
             applyStyleInvocations = 0
             changeStateInvocations = 0

--- a/Tests/Public/Components/Button/Pusable/Pulsable+Spec.swift
+++ b/Tests/Public/Components/Button/Pusable/Pulsable+Spec.swift
@@ -8,7 +8,7 @@ final class PulsableSpec: QuickSpec {
         var pulsableButtonStub: PulsableButtonStub!
 
         beforeEach {
-            ConfigurationStorage.shared.currentTheme = StubThemeProtocol()
+            ConfigurationStorage.shared.currentTheme = StubTheme()
 
             pulsableButtonStub = PulsableButtonStub(
                 frame: .init(

--- a/Tests/Public/Components/Button/Pusable/PulseContainerLayer+Spec.swift
+++ b/Tests/Public/Components/Button/Pusable/PulseContainerLayer+Spec.swift
@@ -8,7 +8,7 @@ final class PulseContainerLayerSpec: QuickSpec {
         var systemUnderTest: PulseContainerLayer!
 
         beforeEach {
-            ConfigurationStorage.shared.currentTheme = StubThemeProtocol()
+            ConfigurationStorage.shared.currentTheme = StubTheme()
 
             systemUnderTest = PulseContainerLayer(color: NatColors.highlight)
         }

--- a/Tests/Public/Components/Dialog/Builders/NatDialogController+AlertStyleBuilder+Spec.swift
+++ b/Tests/Public/Components/Dialog/Builders/NatDialogController+AlertStyleBuilder+Spec.swift
@@ -9,7 +9,7 @@ final class NatDialogControllerAlertStyleBuilderSpec: QuickSpec {
         var viewModel: NatDialogController.ViewModel!
 
         beforeEach {
-            ConfigurationStorage.shared.currentTheme = StubThemeProtocol()
+            ConfigurationStorage.shared.currentTheme = StubTheme()
 
             systemUnderTest = .init()
             viewModel = systemUnderTest.viewModel

--- a/Tests/Public/Components/Dialog/Builders/NatDialogController+StandardStyleBuilder+Spec.swift
+++ b/Tests/Public/Components/Dialog/Builders/NatDialogController+StandardStyleBuilder+Spec.swift
@@ -9,7 +9,7 @@ final class NatDialogControllerStandardStyleBuilderSpec: QuickSpec {
         var viewModel: NatDialogController.ViewModel!
 
         beforeEach {
-            ConfigurationStorage.shared.currentTheme = StubThemeProtocol()
+            ConfigurationStorage.shared.currentTheme = StubTheme()
 
             systemUnderTest = .init()
             viewModel = systemUnderTest.viewModel

--- a/Tests/Public/Components/Dialog/Builders/NatDialogController+ViewModel+Spec.swift
+++ b/Tests/Public/Components/Dialog/Builders/NatDialogController+ViewModel+Spec.swift
@@ -8,7 +8,7 @@ final class NatDialogControllerViewModelSpec: QuickSpec {
         var systemUnderTest: NatDialogController.ViewModel!
 
         beforeEach {
-            ConfigurationStorage.shared.currentTheme = StubThemeProtocol()
+            ConfigurationStorage.shared.currentTheme = StubTheme()
 
             systemUnderTest = .init()
         }

--- a/Tests/Public/Components/Dialog/Builders/Protocols/NatDialogBodyConfigurable+Spec.swift
+++ b/Tests/Public/Components/Dialog/Builders/Protocols/NatDialogBodyConfigurable+Spec.swift
@@ -11,7 +11,7 @@ final class NatDialogBodyConfigurableSpec: QuickSpec {
         var viewModel: NatDialogController.ViewModel!
 
         beforeEach {
-            ConfigurationStorage.shared.currentTheme = StubThemeProtocol()
+            ConfigurationStorage.shared.currentTheme = StubTheme()
 
             systemUnderTest = StubClassWithProtocols()
             viewModel = systemUnderTest.viewModel

--- a/Tests/Public/Components/Dialog/Builders/Protocols/NatDialogCustomBodyConfigurable+Spec.swift
+++ b/Tests/Public/Components/Dialog/Builders/Protocols/NatDialogCustomBodyConfigurable+Spec.swift
@@ -11,7 +11,7 @@ final class NatDialogCustomBodyConfigurableSpec: QuickSpec {
         var viewModel: NatDialogController.ViewModel!
 
         beforeEach {
-            ConfigurationStorage.shared.currentTheme = StubThemeProtocol()
+            ConfigurationStorage.shared.currentTheme = StubTheme()
 
             systemUnderTest = StubClassWithProtocols()
             viewModel = systemUnderTest.viewModel

--- a/Tests/Public/Components/Dialog/Builders/Protocols/NatDialogDismissableConfigurable+Spec.swift
+++ b/Tests/Public/Components/Dialog/Builders/Protocols/NatDialogDismissableConfigurable+Spec.swift
@@ -11,7 +11,7 @@ final class NatDialogDismissableConfigurableSpec: QuickSpec {
         var viewModel: NatDialogController.ViewModel!
 
         beforeEach {
-            ConfigurationStorage.shared.currentTheme = StubThemeProtocol()
+            ConfigurationStorage.shared.currentTheme = StubTheme()
 
             systemUnderTest = StubClassWithProtocols()
             viewModel = systemUnderTest.viewModel

--- a/Tests/Public/Components/Dialog/Builders/Protocols/NatDialogTitleConfigurable+Spec.swift
+++ b/Tests/Public/Components/Dialog/Builders/Protocols/NatDialogTitleConfigurable+Spec.swift
@@ -11,7 +11,7 @@ final class NatDialogTitleConfigurableSpec: QuickSpec {
         var viewModel: NatDialogController.ViewModel!
 
         beforeEach {
-            ConfigurationStorage.shared.currentTheme = StubThemeProtocol()
+            ConfigurationStorage.shared.currentTheme = StubTheme()
 
             systemUnderTest = StubClassWithProtocols()
             viewModel = systemUnderTest.viewModel

--- a/Tests/Public/Components/Dialog/NatDialogController+Spec.swift
+++ b/Tests/Public/Components/Dialog/NatDialogController+Spec.swift
@@ -11,7 +11,7 @@ final class NatDialogControllerSpec: QuickSpec {
             let stubView = UIView()
 
             beforeEach {
-                ConfigurationStorage.shared.currentTheme = StubThemeProtocol()
+                ConfigurationStorage.shared.currentTheme = StubTheme()
 
                 let viewModel = NatDialogController.ViewModel()
                 viewModel.bodyView = stubView

--- a/Tests/Public/Components/ExpansionPanel/ExpansionPanel+MarginTests.swift
+++ b/Tests/Public/Components/ExpansionPanel/ExpansionPanel+MarginTests.swift
@@ -6,7 +6,7 @@ class ExpansionPanelMarginTests: XCTestCase {
     let systemUnderTest = ExpansionPanel.Margin.self
 
     override func setUp() {
-        ConfigurationStorage.shared.currentTheme = StubThemeProtocol()
+        ConfigurationStorage.shared.currentTheme = StubTheme()
     }
 
     func test_horizontalMargin_expectedSpacing() {

--- a/Tests/Public/Components/Field/TextFieldTests.swift
+++ b/Tests/Public/Components/Field/TextFieldTests.swift
@@ -9,7 +9,7 @@ final class TextFieldTests: XCTestCase {
     override func setUp() {
         super.setUp()
 
-        ConfigurationStorage.shared.currentTheme = StubThemeProtocol()
+        ConfigurationStorage.shared.currentTheme = StubTheme()
 
         delegateMock = TextFieldDelegateMock()
         sut = TextField(frame: CGRect(x: 0, y: 0, width: 328, height: 99))

--- a/Tests/Public/Components/IconButton/NatIconButton+Sizes+Specs.swift
+++ b/Tests/Public/Components/IconButton/NatIconButton+Sizes+Specs.swift
@@ -8,7 +8,7 @@ final class NatIconButtonSizesSpecs: QuickSpec {
         let systemUnderTest = NatIconButton.Sizes.self
 
         beforeEach {
-            ConfigurationStorage.shared.currentTheme = StubThemeProtocol()
+            ConfigurationStorage.shared.currentTheme = StubTheme()
         }
 
         describe("#semi") {

--- a/Tests/Public/Components/IconButton/NatIconButton+Spec.swift
+++ b/Tests/Public/Components/IconButton/NatIconButton+Spec.swift
@@ -12,7 +12,7 @@ final class NatIconButtonSpec: QuickSpec {
         var styleSpy: NatIconButton.Style!
 
         beforeEach {
-            ConfigurationStorage.shared.currentTheme = StubThemeProtocol()
+            ConfigurationStorage.shared.currentTheme = StubTheme()
 
             applyStyleInvocations = 0
 

--- a/Tests/Public/Components/Icons/IconViewSpec.swift
+++ b/Tests/Public/Components/Icons/IconViewSpec.swift
@@ -8,7 +8,7 @@ final class IconViewSpec: QuickSpec {
         var sut: IconView!
 
         beforeEach {
-            ConfigurationStorage.shared.currentTheme = StubThemeProtocol()
+            ConfigurationStorage.shared.currentTheme = StubTheme()
         }
 
         describe("#init(fontSize: icon:)") {

--- a/Tests/Public/Components/NavigationDrawer/NavigationDrawerItemCellTests.swift
+++ b/Tests/Public/Components/NavigationDrawer/NavigationDrawerItemCellTests.swift
@@ -8,7 +8,7 @@ final class NavigationDrawerItemCellTests: XCTestCase {
     override func setUp() {
         super.setUp()
 
-        ConfigurationStorage.shared.currentTheme = StubThemeProtocol()
+        ConfigurationStorage.shared.currentTheme = StubTheme()
 
         systemUnderTest = NavigationDrawerItemCell()
         systemUnderTest.frame = CGRect(x: 0, y: 0, width: 320, height: 48)

--- a/Tests/Public/Components/NavigationDrawer/NavigationDrawerSubitemCellTests.swift
+++ b/Tests/Public/Components/NavigationDrawer/NavigationDrawerSubitemCellTests.swift
@@ -8,7 +8,7 @@ final class NavigationDrawerSubitemCellTests: XCTestCase {
     override func setUp() {
         super.setUp()
 
-        ConfigurationStorage.shared.currentTheme = StubThemeProtocol()
+        ConfigurationStorage.shared.currentTheme = StubTheme()
 
         systemUnderTest = NavigationDrawerSubitemCell()
     }

--- a/Tests/Public/Components/NavigationDrawer/NavigationDrawerTests.swift
+++ b/Tests/Public/Components/NavigationDrawer/NavigationDrawerTests.swift
@@ -10,7 +10,7 @@ final class NavigationDrawerTests: XCTestCase {
     override func setUp() {
         super.setUp()
 
-        ConfigurationStorage.shared.currentTheme = StubThemeProtocol()
+        ConfigurationStorage.shared.currentTheme = StubTheme()
 
         tableView = UITableView()
         delegateMock = NavigationDrawerDelegateMock()

--- a/Tests/Public/Components/Shortcut/NatShortcut+Spec.swift
+++ b/Tests/Public/Components/Shortcut/NatShortcut+Spec.swift
@@ -12,7 +12,7 @@ final class NatShortSpec: QuickSpec {
         var notificationCenterSpy: NotificationCenterSpy!
 
         beforeEach {
-            ConfigurationStorage.shared.currentTheme = StubThemeProtocol()
+            ConfigurationStorage.shared.currentTheme = StubTheme()
 
             applyStyleInvocations = 0
 

--- a/Tests/Public/Components/Tab/TabItemViewTests.swift
+++ b/Tests/Public/Components/Tab/TabItemViewTests.swift
@@ -9,7 +9,7 @@ class TabItemViewTests: XCTestCase {
     override func setUp() {
         super.setUp()
 
-        ConfigurationStorage.shared.currentTheme = StubThemeProtocol()
+        ConfigurationStorage.shared.currentTheme = StubTheme()
 
         delegateMock = TabItemViewDelegateMock()
 

--- a/Tests/Public/Components/Tab/TabTests.swift
+++ b/Tests/Public/Components/Tab/TabTests.swift
@@ -11,7 +11,7 @@ final class TabTests: XCTestCase {
     override func setUp() {
         super.setUp()
 
-        ConfigurationStorage.shared.currentTheme = StubThemeProtocol()
+        ConfigurationStorage.shared.currentTheme = StubTheme()
 
         delegateMock = TabDelegateMock()
 

--- a/Tests/Public/DesignSystem+Spec.swift
+++ b/Tests/Public/DesignSystem+Spec.swift
@@ -179,7 +179,7 @@ final class DesignSystemSpec: QuickSpec {
         describe("#currentTheme") {
             context("when the theme is not mapped in AvailableTheme") {
                 beforeEach {
-                    storage.currentTheme = StubThemeProtocol()
+                    storage.currentTheme = StubTheme()
                 }
 
                 it("returns nil") {

--- a/Tests/Public/DesignTokens/NatColorsSpec/NatColors+Spec.swift
+++ b/Tests/Public/DesignTokens/NatColorsSpec/NatColors+Spec.swift
@@ -5,7 +5,7 @@ import Nimble
 
 final class NatColorsSpec: QuickSpec {
     override func spec() {
-        let stubTheme = StubThemeProtocol()
+        let stubTheme = StubTheme()
 
         beforeEach {
             ConfigurationStorage.shared.currentTheme = stubTheme

--- a/Tests/Public/DesignTokens/NatFonts/NatFonts+Spec.swift
+++ b/Tests/Public/DesignTokens/NatFonts/NatFonts+Spec.swift
@@ -9,7 +9,7 @@ final class NatFontsSpec: QuickSpec {
         var font: UIFont!
 
         beforeEach {
-            ConfigurationStorage.shared.currentTheme = StubThemeProtocol()
+            ConfigurationStorage.shared.currentTheme = StubTheme()
         }
 
         describe("#font") {

--- a/Tests/Supporting Files/TestingHelpers/Theme/StubTheme.swift
+++ b/Tests/Supporting Files/TestingHelpers/Theme/StubTheme.swift
@@ -1,11 +1,11 @@
 @testable import NatDS
 
-struct StubThemeProtocol: Theme {
-    let tokens: Tokens = StubTokensProtocol()
-    let components: Components = StubComponentsProtocol()
+struct StubTheme: Theme {
+    let tokens: Tokens = StubTokens()
+    let components: Components = StubComponents()
 }
 
-private struct StubTokensProtocol: Tokens {
+private struct StubTokens: Tokens {
     let borderRadiusNone: CGFloat = 0
     let borderRadiusSmall: CGFloat = 2
     let borderRadiusMedium: CGFloat = 4
@@ -75,7 +75,7 @@ private struct StubTokensProtocol: Tokens {
     let typographyFontWeightMedium: UIFont.Weight = .medium
 }
 
-private struct StubComponentsProtocol: Components {
+private struct StubComponents: Components {
     let buttonDefaultFontSize: CGFloat = 14
     let buttonDefaultFontWeight: UIFont.Weight = .medium
     let buttonDefaultLetterSpacing: CGFloat = 0.44

--- a/Tests/Supporting Files/TestingHelpers/Theme/StubThemeProtocol.swift
+++ b/Tests/Supporting Files/TestingHelpers/Theme/StubThemeProtocol.swift
@@ -1,11 +1,11 @@
 @testable import NatDS
 
-struct StubThemeProtocol: ThemeProtocol {
-    let tokens: TokensProtocol = StubTokensProtocol()
-    let components: ComponentsProtocol = StubComponentsProtocol()
+struct StubThemeProtocol: Theme {
+    let tokens: Tokens = StubTokensProtocol()
+    let components: Components = StubComponentsProtocol()
 }
 
-private struct StubTokensProtocol: TokensProtocol {
+private struct StubTokensProtocol: Tokens {
     let borderRadiusNone: CGFloat = 0
     let borderRadiusSmall: CGFloat = 2
     let borderRadiusMedium: CGFloat = 4
@@ -75,7 +75,7 @@ private struct StubTokensProtocol: TokensProtocol {
     let typographyFontWeightMedium: UIFont.Weight = .medium
 }
 
-private struct StubComponentsProtocol: ComponentsProtocol {
+private struct StubComponentsProtocol: Components {
     let buttonDefaultFontSize: CGFloat = 14
     let buttonDefaultFontWeight: UIFont.Weight = .medium
     let buttonDefaultLetterSpacing: CGFloat = 0.44


### PR DESCRIPTION
# Description

- Remove suffix from theme protocols.
   - `ThemeProtocol`  -> `Theme`
   - `TokensProtocol`  -> `Tokens`
   - `ComponentsProtocol`  -> `Components`

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Internal changes
