### PR TITLE
[DSY-1750] Chore: Bump version to 3.0.0

### DIFF
--- a/NatDS.podspec
+++ b/NatDS.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = 'NatDS'
-  s.version       = '2.12.0'
+  s.version       = '3.0.0'
   s.summary       = 'Natura Group Design System'
   s.description   = <<-DESC
                     Natura Design System helps designers and developers work faster and smarter, ensuring brand consistency and scalability.

--- a/NatDS.xcodeproj/project.pbxproj
+++ b/NatDS.xcodeproj/project.pbxproj
@@ -2925,7 +2925,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.12.0;
+				MARKETING_VERSION = 3.0.0;
 				PRODUCT_BUNDLE_IDENTIFIER = net.natura.NatDS;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
@@ -3140,7 +3140,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.12.0;
+				MARKETING_VERSION = 3.0.0;
 				PRODUCT_BUNDLE_IDENTIFIER = net.natura.NatDS;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;

--- a/SampleApp/NatDS-SampleApp.xcodeproj/project.pbxproj
+++ b/SampleApp/NatDS-SampleApp.xcodeproj/project.pbxproj
@@ -576,7 +576,7 @@
 				648B131410E9C0915BF9C08FDE33DD36 /* Frameworks */,
 				B904DAECF952AB0D904B29291A79794E /* Resources */,
 				BA7D257147E394ADC9BAB095B2BD4E65 /* Embed Frameworks */,
-				6D1BA6CEFBC096856EC7C8BC /* [CP] Embed Pods Frameworks */,
+				5D5293F3352A922FC2708803 /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -655,7 +655,7 @@
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
-		6D1BA6CEFBC096856EC7C8BC /* [CP] Embed Pods Frameworks */ = {
+		5D5293F3352A922FC2708803 /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (

--- a/SampleApp/NatDS-SampleApp.xcodeproj/project.pbxproj
+++ b/SampleApp/NatDS-SampleApp.xcodeproj/project.pbxproj
@@ -761,7 +761,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.12.0;
+				MARKETING_VERSION = 3.0.0;
 				PRODUCT_BUNDLE_IDENTIFIER = net.natura.NatDSSampleApp;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "match Development net.natura.NatDSSampleApp";
@@ -898,7 +898,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.12.0;
+				MARKETING_VERSION = 3.0.0;
 				PRODUCT_BUNDLE_IDENTIFIER = net.natura.NatDSSampleApp;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "match AppStore net.natura.NatDSSampleApp";

--- a/SampleApp/Sources/Sample/Components/AppBar/AppBarDetailViewController.swift
+++ b/SampleApp/Sources/Sample/Components/AppBar/AppBarDetailViewController.swift
@@ -68,11 +68,11 @@ class AppBarDetailViewController: UITableViewController {
         case .noneBarItems:
             configure(buttons: [UIBarButtonItem]())
         case .twoBarItems:
-            let calendarBarButtonItem = UIBarButtonItem(icon: getIcon(icon: .outlinedActionCalendar),
+            let calendarBarButtonItem = UIBarButtonItem(icon: getIcon(.outlinedActionCalendar),
                                                         action: #selector(calendarBarButtonItemHandler),
                                                         target: self)
 
-            let notificationBarButtonItem = UIBarButtonItem(icon: getIcon(icon: .outlinedAlertNotification),
+            let notificationBarButtonItem = UIBarButtonItem(icon: getIcon(.outlinedAlertNotification),
                                                          action: #selector(notificationBarButtonItemHandler),
                                                          target: self)
             notificationBarButtonItem.setBadgeValue(9)

--- a/SampleApp/Sources/Sample/Components/Iconography/IconographyItemViewController.swift
+++ b/SampleApp/Sources/Sample/Components/Iconography/IconographyItemViewController.swift
@@ -26,7 +26,7 @@ class IconographyItemViewController: UIViewController, SampleItem {
 
     private func getAllIcons() -> [String] {
         var icons: [String] = []
-        NatDSIcons.Icon.allCases.forEach { icons.append(getIcon(icon: $0)) }
+        NatDSIcons.Icon.allCases.forEach { icons.append(getIcon($0)) }
         return icons
     }
     

--- a/SampleApp/Sources/Sample/Components/NavigationDrawer/NavigationDrawerItemViewController.swift
+++ b/SampleApp/Sources/Sample/Components/NavigationDrawer/NavigationDrawerItemViewController.swift
@@ -72,20 +72,20 @@ private extension NavigationDrawerItemViewController {
         static func build() -> [Item] {
             let items: [Item] = [
                 Item(label: "Item with no subitems",
-                     icon: NatDSIcons.getIcon(icon: .outlinedFinanceShoppingcart)),
+                     icon: NatDSIcons.getIcon(.outlinedFinanceShoppingcart)),
                 Item(label: "Item with tag",
-                     icon: NatDSIcons.getIcon(icon: .outlinedAlertInfo),
+                     icon: NatDSIcons.getIcon(.outlinedAlertInfo),
                      tagText: "New"),
                 Item(label: "Item with very, very, very large title and tag",
-                     icon: NatDSIcons.getIcon(icon: .outlinedFinanceCards),
+                     icon: NatDSIcons.getIcon(.outlinedFinanceCards),
                      tagText: "New"),
                 Item(label: "Item with one subitem",
-                     icon: NatDSIcons.getIcon(icon: .outlinedActionNewrequest),
+                     icon: NatDSIcons.getIcon(.outlinedActionNewrequest),
                      subitems: [
                         Subitem(label: "Subitem 2.1", disabled: false)
                 ]),
                 Item(label: "Item with very, very, very large title and tag",
-                     icon: NatDSIcons.getIcon(icon: .outlinedActionRequest),
+                     icon: NatDSIcons.getIcon(.outlinedActionRequest),
                      tagText: "New",
                      subitems: [
                         Subitem(label: "Subitem 3.1", disabled: false),
@@ -93,10 +93,10 @@ private extension NavigationDrawerItemViewController {
                         Subitem(label: "Subitem 3.3", disabled: false)
                 ]),
                 Item(label: "Disabled item with no subitem",
-                     icon: NatDSIcons.getIcon(icon: .outlinedSocialGroupofpeople),
+                     icon: NatDSIcons.getIcon(.outlinedSocialGroupofpeople),
                      disabled: true),
                 Item(label: "Disabled item with subitems",
-                     icon: NatDSIcons.getIcon(icon: .filledBrandNaturarosacea),
+                     icon: NatDSIcons.getIcon(.filledBrandNaturarosacea),
                      disabled: true,
                      tagText: "New",
                      subitems: [
@@ -104,7 +104,7 @@ private extension NavigationDrawerItemViewController {
                         Subitem(label: "Subitem 5.2", disabled: false)
                 ]),
                 Item(label: "Item with disabled subitem",
-                   icon: NatDSIcons.getIcon(icon: .outlinedPlaceBus),
+                     icon: NatDSIcons.getIcon(.outlinedPlaceBus),
                      subitems: [
                         Subitem(label: "Subitem 6.1", disabled: true),
                         Subitem(label: "Subitem 6.3", disabled: false),


### PR DESCRIPTION
# Breaking change
From version `3.0.0` NatDS DOES NOT have ICONS anymore. From now on, icons must be added from [NatDSIcons](https://cocoapods.org/pods/NatDSIcons), a new library on Cocoapods.

## Description

- Bumps version to 3.0.0

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update
- [x] Internal changes
