### PR TITLE
Add missing public spacing token

### DIFF
--- a/Sources/Public/DesignTokens/NatSpacing.swift
+++ b/Sources/Public/DesignTokens/NatSpacing.swift
@@ -18,6 +18,7 @@
 */
 
 public enum NatSpacing {
+    public static var none: CGFloat { getTokenFromTheme(\.spacingNone) }
     public static var micro: CGFloat { getTokenFromTheme(\.spacingMicro) }
     public static var tiny: CGFloat { getTokenFromTheme(\.spacingTiny) }
     public static var small: CGFloat { getTokenFromTheme(\.spacingSmall) }


### PR DESCRIPTION
# Description

- Add missing spacing token for public access: `.none`

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Internal changes
