### PR TITLE
[DSY-2050] Fix dialog and value text labels to accept long texts

### DIFF
--- a/Sources/Core/ViewStyling/Dialog/DialogStyle.swift
+++ b/Sources/Core/ViewStyling/Dialog/DialogStyle.swift
@@ -1,6 +1,7 @@
 enum DialogStyle {
     static func createLabelForTitle(title: String) -> UILabel {
         let label = UILabel()
+        label.numberOfLines = 0
         label.font = NatFonts.font(ofSize: .heading6, withWeight: .medium)
 
         let color = getUIColorFromTokens(\.colorHighEmphasis)

--- a/Sources/Public/Components/ValueText/ValueTextHighlight.swift
+++ b/Sources/Public/Components/ValueText/ValueTextHighlight.swift
@@ -42,6 +42,7 @@ public class ValueTextHighlight: UIView {
         label.font = NatFonts.font(ofSize: .body2)
         label.textColor = NatColors.mediumEmphasis
         label.textAlignment = .left
+        label.numberOfLines = 0
 
         return label
     }()


### PR DESCRIPTION
# Description

- Fix long title label for `NatDialog`
- Fix long description label for `Value Text Highlight`

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Internal changes
