### PR TITLE
[DSY-2082] Refactor TextField

### DIFF
--- a/NatDS.xcodeproj/project.pbxproj
+++ b/NatDS.xcodeproj/project.pbxproj
@@ -64,7 +64,6 @@
 		525A8C62B68D8C9B0AC882318792D04C /* Pulsable+Spec.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC00F737F0234FCBD14533100E96A39E /* Pulsable+Spec.swift */; };
 		55A2D6D6BAD3F2F0B352CA80FC656452 /* UICollectionView+ReusableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36B6CEC817D03194414588BB22C1833A /* UICollectionView+ReusableTests.swift */; };
 		56B51E3D524A0D2900D7DD3E6CC761E7 /* UIFont+Icon.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BA9C4721134BD5277D76AEDED7A01DB /* UIFont+Icon.swift */; };
-		56E21DDCD3217649B6CC5332DB901648 /* TextFieldDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB6A44B9A9D7999BD68C1D60499CEF88 /* TextFieldDelegate.swift */; };
 		5737265E1EA6FD9BF1004F1CC1333F29 /* IllustrationIcons.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4969844F4A007C92B7C67A4FA020C85 /* IllustrationIcons.swift */; };
 		5C0716F242EFC1AF6A61CBE257DA7CFE /* TextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 674EEA4A2112FC3EF3AE40AA3776A35A /* TextField.swift */; };
 		5C3B779F94FC59E1F2329996E3E55DF5 /* ElevationAttributes+Equitable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58907D6C652303C4D5FC5FFE6E8F721A /* ElevationAttributes+Equitable.swift */; };
@@ -791,7 +790,6 @@
 		E863AFC8E9DA103F33E2D48577058242 /* NavigationDrawerSubitemCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationDrawerSubitemCell.swift; sourceTree = "<group>"; };
 		E99F543F7F6AC44B9A4E1341942EE0E0 /* TabTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabTests.swift; sourceTree = "<group>"; };
 		EA6C2225E568F933653803F970EF3103 /* Pods_NatDSTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_NatDSTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		EB6A44B9A9D7999BD68C1D60499CEF88 /* TextFieldDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextFieldDelegate.swift; sourceTree = "<group>"; };
 		EBD8F16712FE1A5C351E09A1 /* Pods_NatDSSnapShotTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_NatDSSnapShotTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		EC5970C426475EACCF56EF2C12EB450D /* Pods-NatDSTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NatDSTests.release.xcconfig"; path = "Target Support Files/Pods-NatDSTests/Pods-NatDSTests.release.xcconfig"; sourceTree = "<group>"; };
 		EFD589860DA945AE5563620B305091ED /* NatDS.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = NatDS.h; sourceTree = "<group>"; };
@@ -2680,7 +2678,6 @@
 			children = (
 				8BEE0086E453EC48CFDC60DBA3C5C989 /* Field.swift */,
 				674EEA4A2112FC3EF3AE40AA3776A35A /* TextField.swift */,
-				EB6A44B9A9D7999BD68C1D60499CEF88 /* TextFieldDelegate.swift */,
 				437B78D88ACFB47EEADED96CDC94C7C5 /* TextFieldType.swift */,
 				7D5120CF25ED7CE200557E21 /* TextField+InteractionState.swift */,
 				7D43162C25EE8944004AE34F /* TextField+FeedbackState.swift */,
@@ -3294,7 +3291,6 @@
 				8409854724F02B230095D6AD /* Notification+Name+ThemeHasChanged.swift in Sources */,
 				5C0716F242EFC1AF6A61CBE257DA7CFE /* TextField.swift in Sources */,
 				79EA0C20260A85DE00742C0A /* NatCounterButton.swift in Sources */,
-				56E21DDCD3217649B6CC5332DB901648 /* TextFieldDelegate.swift in Sources */,
 				E07925C3535D79164EBC061C7D6A6CE4 /* TextFieldType.swift in Sources */,
 				847C829224E36AB7001CE116 /* NaturaLightTheme.swift in Sources */,
 				84932F1324EAB9270052265F /* AvailableTheme.swift in Sources */,

--- a/NatDSSnapShotTests/TextField/TextField+Snapshot+Tests.swift
+++ b/NatDSSnapShotTests/TextField/TextField+Snapshot+Tests.swift
@@ -19,7 +19,7 @@ final class TextFieldSnapshotTests: XCTestCase {
         systemUnderTest.title = "Label"
         systemUnderTest.placeholder = "Placeholder"
         systemUnderTest.helper = "Helper Text"
-        systemUnderTest.delegate = delegateMock
+        systemUnderTest.delegate = self
     }
 
     func test_size_whenHasMediumSize_returnMediumSizeSnapshot() {
@@ -38,12 +38,12 @@ final class TextFieldSnapshotTests: XCTestCase {
     }
 
     func test_state_whenHasNoFocus_returnEnableStateSnapshot() {
-        systemUnderTest.textFieldDidEndEditing(systemUnderTest.textField)
+        systemUnderTest.setIsEditing(false)
         assertSnapshot(matching: systemUnderTest, as: .image)
     }
 
     func test_state_whenHasFocus_returnActiveStateSnapshot() {
-        systemUnderTest.textFieldDidBeginEditing(systemUnderTest.textField)
+        systemUnderTest.setIsEditing(true)
         assertSnapshot(matching: systemUnderTest, as: .image)
     }
 
@@ -123,3 +123,5 @@ final class TextFieldSnapshotTests: XCTestCase {
         assertSnapshot(matching: systemUnderTest, as: .image)
     }
 }
+
+extension TextFieldSnapshotTests: UITextFieldDelegate {}

--- a/NatDSSnapShotTests/TextField/TextField+Snapshot+Tests.swift
+++ b/NatDSSnapShotTests/TextField/TextField+Snapshot+Tests.swift
@@ -112,21 +112,6 @@ final class TextFieldSnapshotTests: XCTestCase {
         assertSnapshot(matching: systemUnderTest, as: .image(precision: 0.97))
     }
 
-    func test_password_whenVisibilityIconIsSet_expectedShowIconOutlinedActionVisibility() {
-        systemUnderTest.type = .password(keyboardType: .default)
-        systemUnderTest.text = "999.999.999-99"
-        systemUnderTest.showVisibilityIcon()
-        assertSnapshot(matching: systemUnderTest, as: .image)
-    }
-
-    func test_password_whenVisibilityIconIsSet_expectedShowIconOutlinedActionVisibilityOff() {
-        systemUnderTest.type = .password(keyboardType: .default)
-        systemUnderTest.text = "999.999.999-99"
-        systemUnderTest.showVisibilityIcon()
-        systemUnderTest.setIconVisibility()
-        assertSnapshot(matching: systemUnderTest, as: .image)
-    }
-
     func test_actionIcon_whenHasActionIcon_showsExpectedIconButtonSnapshot() {
         systemUnderTest.configure(icon: nil) {}
         assertSnapshot(matching: systemUnderTest, as: .image)

--- a/SampleApp/Sources/Sample/Components/Field/TextFieldItemViewController.swift
+++ b/SampleApp/Sources/Sample/Components/Field/TextFieldItemViewController.swift
@@ -63,7 +63,6 @@ class TextFieldItemViewController: UIViewController, SampleItem {
         field.type = .password(keyboardType: .numberPad)
         field.placeholder = "Type your password (only numbers)"
         field.delegate = self
-        field.showVisibilityIcon()
         return field
     }()
 

--- a/SampleApp/Sources/Sample/Components/Field/TextFieldItemViewController.swift
+++ b/SampleApp/Sources/Sample/Components/Field/TextFieldItemViewController.swift
@@ -264,4 +264,4 @@ class TextFieldItemViewController: UIViewController, SampleItem {
     }
 }
 
-extension TextFieldItemViewController: TextFieldDelegate {}
+extension TextFieldItemViewController: UITextFieldDelegate {}

--- a/Sources/Public/Components/Field/Field.swift
+++ b/Sources/Public/Components/Field/Field.swift
@@ -1,6 +1,6 @@
-class Field: UITextField {
+public final class Field: UITextField {
 
-    override var placeholder: String? {
+    public override var placeholder: String? {
         didSet {
             let attrPlaceholder = NSMutableAttributedString(string: placeholder ?? "")
                 .apply(font: NatFonts.font(ofSize: .body1, withWeight: .regular))
@@ -42,15 +42,15 @@ class Field: UITextField {
         fatalError("init(coder:) has not been implemented")
     }
 
-    override func textRect(forBounds bounds: CGRect) -> CGRect {
+    public override func textRect(forBounds bounds: CGRect) -> CGRect {
         return bounds.inset(by: padding)
     }
 
-    override func placeholderRect(forBounds bounds: CGRect) -> CGRect {
+    public override func placeholderRect(forBounds bounds: CGRect) -> CGRect {
         return bounds.inset(by: padding)
     }
 
-    override func editingRect(forBounds bounds: CGRect) -> CGRect {
+    public override func editingRect(forBounds bounds: CGRect) -> CGRect {
         return bounds.inset(by: padding)
     }
 

--- a/Sources/Public/Components/Field/TextField+FeedbackState.swift
+++ b/Sources/Public/Components/Field/TextField+FeedbackState.swift
@@ -14,5 +14,36 @@ extension TextField {
         case error
         case success
         case none
+        
+        var borderWidth: CGFloat {
+            switch self {
+            case .error:
+                return 2
+            default:
+                return 1
+            }
+        }
+
+        var tintColor: UIColor {
+            switch self {
+            case .error:
+                return getUIColorFromTokens(\.colorAlert)
+            case .success:
+                return getUIColorFromTokens(\.colorSuccess)
+            default:
+                return .clear
+            }
+        }
+
+        var helperIcon: UIImage? {
+            switch self {
+            case .error:
+                return AssetsPath.iconOutlinedActionCancel.rawValue
+            case .success:
+                return AssetsPath.iconOutlinedActionCheck.rawValue
+            default:
+                return nil
+            }
+        }
     }
 }

--- a/Sources/Public/Components/Field/TextField+FeedbackState.swift
+++ b/Sources/Public/Components/Field/TextField+FeedbackState.swift
@@ -14,7 +14,7 @@ extension TextField {
         case error
         case success
         case none
-        
+
         var borderWidth: CGFloat {
             switch self {
             case .error:

--- a/Sources/Public/Components/Field/TextField+InteractionState.swift
+++ b/Sources/Public/Components/Field/TextField+InteractionState.swift
@@ -14,5 +14,107 @@ extension TextField {
                 return true
             }
         }
+
+        var borderWidth: CGFloat {
+            switch self {
+            case .active:
+                return 2
+            default:
+                return 1
+            }
+        }
+
+        var borderColor: UIColor {
+            switch self {
+            case .enabled, .readOnly, .disabled:
+                return getUIColorFromTokens(\.colorLowEmphasis)
+            case .active:
+                return getUIColorFromTokens(\.colorPrimary)
+            case .filled:
+                return getUIColorFromTokens(\.colorHighEmphasis)
+            }
+        }
+
+        var textColor: UIColor {
+            switch self {
+            case .enabled:
+                return getUIColorFromTokens(\.colorHighEmphasis)
+            case .readOnly:
+                return getUIColorFromTokens(\.colorHighEmphasis)
+            case .disabled:
+                return getUIColorFromTokens(\.colorLowEmphasis)
+            case .active:
+                return getUIColorFromTokens(\.colorHighEmphasis)
+            case .filled:
+                return getUIColorFromTokens(\.colorHighEmphasis)
+            }
+        }
+
+        var titleTextColor: UIColor {
+            switch self {
+            case .enabled:
+                return getUIColorFromTokens(\.colorMediumEmphasis)
+            case .readOnly:
+                return getUIColorFromTokens(\.colorMediumEmphasis)
+            case .disabled:
+                return getUIColorFromTokens(\.colorLowEmphasis)
+            case .active:
+                return getUIColorFromTokens(\.colorMediumEmphasis)
+            case .filled:
+                return getUIColorFromTokens(\.colorMediumEmphasis)
+            }
+        }
+
+        var helperLabelTextColor: UIColor {
+            switch self {
+            case .enabled:
+                return getUIColorFromTokens(\.colorMediumEmphasis)
+            case .readOnly:
+                return getUIColorFromTokens(\.colorMediumEmphasis)
+            case .disabled:
+                return getUIColorFromTokens(\.colorLowEmphasis)
+            case .active:
+                return getUIColorFromTokens(\.colorMediumEmphasis)
+            case .filled:
+                return getUIColorFromTokens(\.colorMediumEmphasis)
+            }
+        }
+
+        var textFieldBackgroundColor: UIColor {
+            switch self {
+            case .readOnly:
+                return getUIColorFromTokens(\.colorLowEmphasis).withAlphaComponent(0.25)
+            default:
+                return .clear
+            }
+        }
+
+        var iconColor: UIColor {
+            switch self {
+            case .enabled:
+                return getUIColorFromTokens(\.colorHighlight)
+            case .readOnly:
+                return getUIColorFromTokens(\.colorHighEmphasis)
+            case .disabled:
+                return getUIColorFromTokens(\.colorLowEmphasis)
+            case .active:
+                return getUIColorFromTokens(\.colorHighlight)
+            case .filled:
+                return getUIColorFromTokens(\.colorHighEmphasis)
+            }
+        }
+
+        var textFieldTintColor: UIColor {
+            return getUIColorFromTokens(\.colorPrimary)
+        }
+
+        var placeholderTextColor: UIColor {
+            switch self {
+            case .enabled, .active:
+                return getUIColorFromTokens(\.colorMediumEmphasis)
+            default:
+                return getUIColorFromTokens(\.colorLowEmphasis)
+            }
+        }
     }
 }

--- a/Sources/Public/Components/Field/TextField+InteractionState.swift
+++ b/Sources/Public/Components/Field/TextField+InteractionState.swift
@@ -8,7 +8,8 @@ extension TextField {
 
         var isUserInteractionEnabled: Bool {
             switch self {
-            case .disabled, .readOnly:
+            case .disabled,
+                 .readOnly:
                 return false
             default:
                 return true
@@ -26,7 +27,9 @@ extension TextField {
 
         var borderColor: UIColor {
             switch self {
-            case .enabled, .readOnly, .disabled:
+            case .enabled,
+                 .readOnly,
+                 .disabled:
                 return getUIColorFromTokens(\.colorLowEmphasis)
             case .active:
                 return getUIColorFromTokens(\.colorPrimary)
@@ -110,7 +113,8 @@ extension TextField {
 
         var placeholderTextColor: UIColor {
             switch self {
-            case .enabled, .active:
+            case .enabled,
+                 .active:
                 return getUIColorFromTokens(\.colorMediumEmphasis)
             default:
                 return getUIColorFromTokens(\.colorLowEmphasis)

--- a/Sources/Public/Components/Field/TextField+InteractionState.swift
+++ b/Sources/Public/Components/Field/TextField+InteractionState.swift
@@ -114,7 +114,8 @@ extension TextField {
         var placeholderTextColor: UIColor {
             switch self {
             case .enabled,
-                 .active:
+                 .active,
+                 .readOnly:
                 return getUIColorFromTokens(\.colorMediumEmphasis)
             default:
                 return getUIColorFromTokens(\.colorLowEmphasis)

--- a/Sources/Public/Components/Field/TextField.swift
+++ b/Sources/Public/Components/Field/TextField.swift
@@ -528,3 +528,12 @@ extension TextField {
         self.textField.delegate = delegate
     }
 }
+
+extension TextField {
+    // MARK: - Internal methods
+
+    /// Internal method as a helper to run snapshot tests.
+    internal func setIsEditing(_ isEditing: Bool) {
+        self.isEditing = isEditing
+    }
+}

--- a/Sources/Public/Components/Field/TextField.swift
+++ b/Sources/Public/Components/Field/TextField.swift
@@ -1,6 +1,36 @@
 // swiftlint:disable line_length
 // swiftlint:disable file_length
 /**
+ - NOTE:
+ This component is available in the following variants:
+ - ✅ Standard
+
+ With the following attribute status:
+ - ✅ Disabled
+ - ✅ Read-only
+ - ✅ Helper text
+ - Size:
+    - ✅ `MediumX`
+    - ✅ `Medium`
+ - Style:
+    - ✅ `Outlined`
+ - Interaction state:
+    - ✅ `Enabled`
+    - ✅ `Active (focus)`
+    - ✅ `Filled `
+ - Feedback state:
+    - ✅ `Error`
+    - ✅ `Success`
+ - Action:
+    - ✅ `None`
+    - ✅ `Icon button`
+    - ✅ `Image`
+ - Type:
+    - ✅ `Text`
+    - ✅ `Password`
+    - ✅ `Number`
+    - ❌ `Multiline`
+ 
  TextField is a class that represents a component from the design system.
  
  It can be configured with 2 different sizes:
@@ -44,15 +74,9 @@
  
  The TextField also has an action item on the right, which can be configured with an icon from NatDSIcons, a local image or a remote image:
  
-        textField.configure(icon: getIcon(.outlinedDefaultMockup)) {
-            // action
-        }
-        field.configure(image: UIImage(named: "imageName")) {
-            // action
-        }
-        field.configure(remoteImageURL: URL(string: "urlForImage")) {
-            // action
-        }
+        textField.configure(icon: getIcon(.outlinedDefaultMockup)) { action }
+        textField.configure(image: UIImage(named: "imageName")) { action }
+        textField.configure(remoteImageURL: URL(string: "urlForImage")) { action }
 
  There are properties that changes the textfield styles as well.
 
@@ -62,7 +86,7 @@
  - `helper`: Hint text always displayed below textfield
  - `error`: Text that alerts about an error
  
- To manage the TextField, use UITextFieldDelegate protocol.
+ To manage the TextField, use UITextFieldDelegate protocol as usual.
  
         textField.delegate = yourDelegate
 

--- a/Sources/Public/Components/Field/TextField.swift
+++ b/Sources/Public/Components/Field/TextField.swift
@@ -522,7 +522,7 @@ extension TextField {
             actionImageView.removeFromSuperview()
         }
     }
-    
+
     /// Sets a delegate for the TextField
     public func configure(delegate: UITextFieldDelegate?) {
         self.textField.delegate = delegate

--- a/Sources/Public/Components/Field/TextField.swift
+++ b/Sources/Public/Components/Field/TextField.swift
@@ -213,24 +213,6 @@ public class TextField: UIView {
         return iconView
     }()
 
-    private lazy var iconVisibility: UIImage? = {
-        let icon = AssetsPath.iconOutlinedActionVisibility.rawValue
-        return icon
-    }()
-
-    private lazy var iconButtonVisibility: NatIconButton = {
-        let iconButton = NatIconButton(style: .standardDefault)
-        iconButton.configure(iconImage: iconVisibility)
-        iconButton.configure {
-            self.setIconVisibility()
-        }
-        iconButton.translatesAutoresizingMaskIntoConstraints = false
-        iconButton.heightAnchor.constraint(equalToConstant: getTokenFromTheme(\.sizeSemi)).isActive = true
-        iconButton.widthAnchor.constraint(equalToConstant: getTokenFromTheme(\.sizeSemi)).isActive = true
-
-        return iconButton
-    }()
-
     private lazy var iconButtonGeneral: NatIconButton = {
         let iconButton = NatIconButton(style: .standardDefault)
         iconButton.translatesAutoresizingMaskIntoConstraints = false
@@ -356,7 +338,6 @@ extension TextField {
     private func handleInteractionState() {
         textField.isEnabled = self.interactionState.isUserInteractionEnabled
         iconButtonGeneral.isUserInteractionEnabled = self.interactionState.isUserInteractionEnabled
-        iconButtonVisibility.isUserInteractionEnabled = self.interactionState.isUserInteractionEnabled
     }
 
     private func handleInteractionStateStyle() {
@@ -372,7 +353,6 @@ extension TextField {
         titleLabel.textColor = interactionState.titleTextColor
         helperLabel.textColor = interactionState.helperLabelTextColor
         iconButtonGeneral.configure(iconColor: interactionState.iconColor)
-        iconButtonVisibility.tintColor = interactionState.iconColor
 
         helperLabel.text = helper
     }
@@ -426,41 +406,6 @@ extension TextField {
         actionImageView.topAnchor.constraint(equalTo: textField.topAnchor, constant: 2).isActive = true
         actionImageView.bottomAnchor.constraint(equalTo: textField.bottomAnchor, constant: -2).isActive = true
         actionImageView.widthAnchor.constraint(equalToConstant: getTokenFromTheme(\.sizeLarge)).isActive = true
-    }
-
-    public func showVisibilityIcon() {
-        if self.type.secureTextEntry {
-            if self.subviews.contains(iconButtonGeneral) {
-                self.iconButtonGeneral.removeFromSuperview()
-            }
-
-            addSubview(iconButtonVisibility)
-            textField.fitPaddingToIconButton()
-
-            let constraints = [
-                iconButtonVisibility.centerYAnchor.constraint(equalTo: textField.centerYAnchor),
-                iconButtonVisibility.trailingAnchor.constraint(equalTo: textField.trailingAnchor, constant: -12)
-            ]
-            NSLayoutConstraint.activate(constraints)
-        }
-    }
-
-    public func hideVisibilityIcon() {
-        if self.subviews.contains(iconButtonVisibility) {
-            self.iconButtonVisibility.removeFromSuperview()
-        }
-    }
-
-    internal func setIconVisibility() {
-        if iconVisibility == AssetsPath.iconOutlinedActionVisibility.rawValue {
-            iconVisibility = AssetsPath.iconOutlinedActionVisibilityOff.rawValue
-            iconButtonVisibility.configure(iconImage: iconVisibility)
-            self.textField.isSecureTextEntry = false
-        } else {
-            iconVisibility = AssetsPath.iconOutlinedActionVisibility.rawValue
-            iconButtonVisibility.configure(iconImage: iconVisibility)
-            self.textField.isSecureTextEntry = true
-        }
     }
 }
 
@@ -531,7 +476,6 @@ extension TextField {
     ///   - action: A block of code to be executed when the icon receives a tap.
     public func configure(icon: String?, with action: @escaping () -> Void) {
         configureRemoveAction()
-        hideVisibilityIcon()
         textField.fitPaddingToIconButton()
         addIconButtonGeneral()
         iconButtonGeneral.configure(action: action)
@@ -549,7 +493,6 @@ extension TextField {
     ///   - action: A block of code to be executed when the image is tapped
     public func configure(image: UIImage?, with action: @escaping () -> Void) {
         configureRemoveAction()
-        hideVisibilityIcon()
         textField.fitPaddingToImage()
         addActionImage()
         actionImageView.image = image
@@ -563,7 +506,6 @@ extension TextField {
     ///   - action: A block of code the be executed when the image is tapped
     public func configure(remoteImageURL: URL, with action: @escaping () -> Void) {
         configureRemoveAction()
-        hideVisibilityIcon()
         textField.fitPaddingToImage()
         addActionImage()
         actionImageView.load(url: remoteImageURL)
@@ -579,16 +521,6 @@ extension TextField {
         if self.subviews.contains(actionImageView) {
             actionImageView.removeFromSuperview()
         }
-    }
-
-    /// Sets the eye icon to show and hide the textField content. It can only be used if the textField has the `password` type.
-    public func configureShowVisibilityIcon() {
-        showVisibilityIcon()
-    }
-
-    /// Removes the eye icon from `password` type textFields.
-    public func configureRemoveVisibilityIcon() {
-        hideVisibilityIcon()
     }
     
     /// Sets a delegate for the TextField

--- a/Sources/Public/Components/Field/TextField.swift
+++ b/Sources/Public/Components/Field/TextField.swift
@@ -180,7 +180,7 @@ public class TextField: UIView {
         return label
     }()
 
-    private(set) lazy var textField: Field = {
+    public private(set) lazy var textField: Field = {
         let field = Field()
         field.delegate = self
         return field
@@ -212,16 +212,6 @@ public class TextField: UIView {
 
     private lazy var iconVisibility: UIImage? = {
         let icon = AssetsPath.iconOutlinedActionVisibility.rawValue
-        return icon
-    }()
-
-    private lazy var iconCheck: UIImage? = {
-        let icon = AssetsPath.iconOutlinedActionCheck.rawValue
-        return icon
-    }()
-
-    private lazy var iconCancel: UIImage? = {
-        let icon = AssetsPath.iconOutlinedActionCancel.rawValue
         return icon
     }()
 
@@ -307,7 +297,6 @@ extension TextField {
             titleLabel.leadingAnchor.constraint(equalTo: leadingAnchor),
             titleLabel.trailingAnchor.constraint(equalTo: trailingAnchor)
         ]
-
         NSLayoutConstraint.activate(constraints)
     }
 
@@ -315,11 +304,12 @@ extension TextField {
         addSubview(textField)
         textField.translatesAutoresizingMaskIntoConstraints = false
 
-        NSLayoutConstraint.activate([
+        let constraints = [
             textField.topAnchor.constraint(equalTo: titleLabel.bottomAnchor, constant: 4),
             textField.leadingAnchor.constraint(equalTo: leadingAnchor),
             textField.trailingAnchor.constraint(equalTo: trailingAnchor)
-        ])
+        ]
+        NSLayoutConstraint.activate(constraints)
         updateTextFieldHeightConstraint()
     }
 
@@ -338,7 +328,6 @@ extension TextField {
             stackView.bottomAnchor.constraint(equalTo: bottomAnchor),
             stackView.trailingAnchor.constraint(equalTo: trailingAnchor)
         ]
-
         NSLayoutConstraint.activate(constraints)
     }
 }
@@ -359,114 +348,50 @@ extension TextField {
         iconButtonVisibility.isUserInteractionEnabled = self.interactionState.isUserInteractionEnabled
     }
 
-    // swiftlint:disable function_body_length
     private func handleInteractionStateStyle() {
-        switch interactionState {
-        case .enabled:
-            textField.borderWidth = 1
-            textField.borderColor = getUIColorFromTokens(\.colorLowEmphasis)
-            titleLabel.textColor = getUIColorFromTokens(\.colorMediumEmphasis)
-            helperLabel.textColor = getUIColorFromTokens(\.colorMediumEmphasis)
-            helperLabel.text = helper
-            iconButtonVisibility.tintColor = getUIColorFromTokens(\.colorHighlight)
-            iconButtonGeneral.configure(iconColor: getUIColorFromTokens(\.colorHighlight))
-            textField.textColor = getUIColorFromTokens(\.colorHighEmphasis)
-            textField.backgroundColor = .clear
-            textField.attributedPlaceholder = NSAttributedString(string: placeholder ?? "",
-                                                                 attributes: [NSAttributedString.Key.foregroundColor:
-                                                                                getUIColorFromTokens(\.colorMediumEmphasis)])
+        textField.borderWidth = interactionState.borderWidth
+        textField.borderColor = interactionState.borderColor
+        textField.textColor = interactionState.textColor
+        textField.backgroundColor = interactionState.textFieldBackgroundColor
+        textField.tintColor = interactionState.textFieldTintColor
+        textField.attributedPlaceholder = NSAttributedString(string: placeholder ?? "",
+                                                             attributes: [NSAttributedString.Key.foregroundColor:
+                                                                            interactionState.placeholderTextColor])
 
-        case .active:
-            textField.borderWidth = 2
-            textField.borderColor = getUIColorFromTokens(\.colorPrimary)
-            textField.tintColor = getUIColorFromTokens(\.colorPrimary)
-            titleLabel.textColor = getUIColorFromTokens(\.colorMediumEmphasis)
-            helperLabel.textColor = getUIColorFromTokens(\.colorMediumEmphasis)
-            helperLabel.text = helper
-            textField.textColor = getUIColorFromTokens(\.colorHighEmphasis)
-            textField.backgroundColor = .clear
-            textField.attributedPlaceholder = NSAttributedString(string: placeholder ?? "",
-                                                                 attributes: [NSAttributedString.Key.foregroundColor:
-                                                                                getUIColorFromTokens(\.colorMediumEmphasis)])
+        titleLabel.textColor = interactionState.titleTextColor
+        helperLabel.textColor = interactionState.helperLabelTextColor
+        iconButtonGeneral.configure(iconColor: interactionState.iconColor)
+        iconButtonVisibility.tintColor = interactionState.iconColor
 
-        case .readOnly:
-            textField.borderWidth = 1
-            textField.borderColor = getUIColorFromTokens(\.colorLowEmphasis)
-            titleLabel.textColor = getUIColorFromTokens(\.colorMediumEmphasis)
-            helperLabel.textColor = getUIColorFromTokens(\.colorMediumEmphasis)
-            textField.backgroundColor = getUIColorFromTokens(\.colorLowEmphasis).withAlphaComponent(0.25)
-            helperLabel.text = helper
-            textField.textColor = getUIColorFromTokens(\.colorHighEmphasis)
-            iconButtonVisibility.tintColor = getUIColorFromTokens(\.colorHighEmphasis)
-            iconButtonGeneral.configure(iconColor: getUIColorFromTokens(\.colorHighEmphasis))
-
-        case .disabled:
-            textField.borderWidth = 1
-            textField.borderColor = getUIColorFromTokens(\.colorLowEmphasis)
-            textField.textColor = getUIColorFromTokens(\.colorLowEmphasis)
-            titleLabel.textColor = getUIColorFromTokens(\.colorLowEmphasis)
-            helperLabel.textColor = getUIColorFromTokens(\.colorLowEmphasis)
-            helperLabel.text = helper
-            iconButtonVisibility.tintColor = getUIColorFromTokens(\.colorLowEmphasis)
-            iconButtonGeneral.configure(iconColor: getUIColorFromTokens(\.colorLowEmphasis))
-            textField.backgroundColor = .clear
-            textField.attributedPlaceholder = NSAttributedString(string: placeholder ?? "",
-                                                                 attributes: [NSAttributedString.Key.foregroundColor:
-                                                                                getUIColorFromTokens(\.colorLowEmphasis)])
-
-        case .filled:
-            textField.borderWidth = 1
-            textField.borderColor = getUIColorFromTokens(\.colorHighEmphasis)
-            titleLabel.textColor = getUIColorFromTokens(\.colorMediumEmphasis)
-            helperLabel.textColor = getUIColorFromTokens(\.colorMediumEmphasis)
-            helperLabel.text = helper
-            iconButtonVisibility.tintColor = getUIColorFromTokens(\.colorHighEmphasis)
-            iconButtonGeneral.configure(iconColor: getUIColorFromTokens(\.colorHighEmphasis))
-            textField.textColor = getUIColorFromTokens(\.colorHighEmphasis)
-            textField.backgroundColor = .clear
-        }
+        helperLabel.text = helper
     }
 
     private func handleFeedbackStyle() {
-        switch state {
-        case .error:
-            textField.borderWidth = 2
-            textField.borderColor = getUIColorFromTokens(\.colorAlert)
-            textField.tintColor = getUIColorFromTokens(\.colorAlert)
-            titleLabel.textColor = getUIColorFromTokens(\.colorAlert)
-            helperLabel.textColor = getUIColorFromTokens(\.colorAlert)
-            helperLabel.text = helper
-            stackView.spacing = getTokenFromTheme(\.sizeMicro)
-            feedbackIconImageView.image = iconCancel
-            feedbackIconImageView.contentMode = .scaleAspectFit
-            feedbackIconImageView.tintedColor = getUIColorFromTokens(\.colorAlert)
-            feedbackIconImageView.isHidden = false
-
-        case .success:
-            textField.borderWidth = 1
-            textField.borderColor = getUIColorFromTokens(\.colorSuccess)
-            textField.tintColor = getUIColorFromTokens(\.colorSuccess)
-            titleLabel.textColor = getUIColorFromTokens(\.colorSuccess)
-            helperLabel.textColor = getUIColorFromTokens(\.colorSuccess)
-            helperLabel.text = helper
-            stackView.spacing = getTokenFromTheme(\.sizeMicro)
-            feedbackIconImageView.image = iconCheck
-            feedbackIconImageView.contentMode = .scaleAspectFit
-            feedbackIconImageView.tintedColor = getUIColorFromTokens(\.colorSuccess)
-            feedbackIconImageView.isHidden = false
-
-        default:
+        if state == .none {
             handleInteractionStateStyle()
             feedbackIconImageView.isHidden = true
             return
         }
+
+        textField.borderWidth = state.borderWidth
+        textField.borderColor = state.tintColor
+        textField.tintColor = state.tintColor
+        titleLabel.textColor = state.tintColor
+        helperLabel.textColor = state.tintColor
+        helperLabel.text = helper
+
+        stackView.spacing = getTokenFromTheme(\.sizeMicro)
+        feedbackIconImageView.image = state.helperIcon
+        feedbackIconImageView.contentMode = .scaleAspectFit
+        feedbackIconImageView.tintedColor = state.tintColor
+        feedbackIconImageView.isHidden = false
     }
 
     private func handleTextFieldType() {
-        self.textField.keyboardType = type.keyboard
-        self.textField.autocorrectionType = type.autoCorrection
-        self.textField.autocapitalizationType = type.capitalization
-        self.textField.isSecureTextEntry = type.secureTextEntry
+        textField.keyboardType = type.keyboard
+        textField.autocorrectionType = type.autoCorrection
+        textField.autocapitalizationType = type.capitalization
+        textField.isSecureTextEntry = type.secureTextEntry
     }
 
     private func handleRequired() {
@@ -480,8 +405,8 @@ extension TextField {
 
     private func addIconButtonGeneral() {
         addSubview(iconButtonGeneral)
-        self.iconButtonGeneral.centerYAnchor.constraint(equalTo: textField.centerYAnchor).isActive = true
-        self.iconButtonGeneral.trailingAnchor.constraint(equalTo: textField.trailingAnchor, constant: -12).isActive = true
+        iconButtonGeneral.centerYAnchor.constraint(equalTo: textField.centerYAnchor).isActive = true
+        iconButtonGeneral.trailingAnchor.constraint(equalTo: textField.trailingAnchor, constant: -12).isActive = true
     }
 
     private func addActionImage() {

--- a/Sources/Public/Components/Field/TextFieldDelegate.swift
+++ b/Sources/Public/Components/Field/TextFieldDelegate.swift
@@ -1,8 +1,0 @@
-@objc public protocol TextFieldDelegate: AnyObject {
-
-    @objc optional func natTextFieldDidBeginEditing(_ textField: TextField)
-    @objc optional func natTextFieldDidEndEditing(_ textField: TextField)
-    @objc optional func natTextFieldEditingChanged(_ textField: TextField)
-    @objc optional func natTextFieldShouldBeginEditing(_ textField: TextField) -> Bool
-    @objc optional func natTextField(_ textField: TextField, changeCharInRange: NSRange, string: String) -> Bool
-}

--- a/Sources/Public/Components/Field/TextFieldType.swift
+++ b/Sources/Public/Components/Field/TextFieldType.swift
@@ -17,9 +17,8 @@ public enum TextFieldType {
 
     var keyboard: UIKeyboardType {
         switch self {
-        case .text:
-            return .default
-        case .name:
+        case .text,
+             .name:
             return .default
         case .number:
             return .numberPad
@@ -32,38 +31,26 @@ public enum TextFieldType {
         switch self {
         case .text:
             return .yes
-        case .name:
-            return .no
-        case .number:
-            return .no
-        case .password:
+        default:
             return .no
         }
     }
 
     var capitalization: UITextAutocapitalizationType {
          switch self {
-         case .text:
-             return .none
          case .name:
             return .words
-         case .number:
-             return .none
-         case .password:
+         default:
             return .none
          }
      }
 
     var secureTextEntry: Bool {
         switch self {
-        case .text:
-            return false
-        case .name:
-            return false
-        case .number:
-            return false
         case .password:
             return true
+        default:
+            return false
         }
     }
 }

--- a/TestHelpers/TextField/TextFieldDelegateMock.swift
+++ b/TestHelpers/TextField/TextFieldDelegateMock.swift
@@ -2,30 +2,33 @@ import Foundation
 
 @testable import NatDS
 
-final class TextFieldDelegateMock: TextFieldDelegate {
+class TextFieldDelegateMock: NSObject {
+    var invokedDidBeginEditing: (count: Int, field: UITextField?) = (count: 0, field: nil)
+    var invokedDidEndEditing: (count: Int, field: UITextField?) = (count: 0, field: nil)
+    var invokedDidShouldBeginEditing: (count: Int, field: UITextField?) = (count: 0, field: nil)
+    var invokedTextFieldChangeCharInRange: (count: Int, field: UITextField?) = (count: 0, field: nil)
+}
 
-    var invokedDidBeginEditing: (count: Int, field: TextField?) = (count: 0, field: nil)
-    var invokedDidEndEditing: (count: Int, field: TextField?) = (count: 0, field: nil)
-    var invokedDidShouldBeginEditing: (count: Int, field: TextField?) = (count: 0, field: nil)
-    var invokedTextFieldChangeCharInRange: (count: Int, field: TextField?) = (count: 0, field: nil)
-
-    func natTextFieldDidBeginEditing(_ textField: TextField) {
+extension TextFieldDelegateMock: UITextFieldDelegate {
+    func textFieldDidBeginEditing(_ textField: UITextField) {
         invokedDidBeginEditing.count += 1
         invokedDidBeginEditing.field = textField
     }
 
-    func natTextFieldDidEndEditing(_ textField: TextField) {
+    func textFieldDidEndEditing(_ textField: UITextField) {
         invokedDidEndEditing.count += 1
         invokedDidEndEditing.field = textField
     }
 
-    func natTextFieldShouldBeginEditing(_ textField: TextField) -> Bool {
+    func textFieldShouldBeginEditing(_ textField: UITextField) -> Bool {
         invokedDidShouldBeginEditing.count += 1
         invokedDidShouldBeginEditing.field = textField
         return true
     }
 
-    func natTextField(_ textField: TextField, changeCharInRange: NSRange, string: String) -> Bool {
+    func textField(_ textField: UITextField,
+                   shouldChangeCharactersIn range: NSRange,
+                   replacementString string: String) -> Bool {
         invokedTextFieldChangeCharInRange.count += 1
         invokedTextFieldChangeCharInRange.field = textField
         return true

--- a/Tests/Public/Components/Field/TextField+Types+Spec.swift
+++ b/Tests/Public/Components/Field/TextField+Types+Spec.swift
@@ -39,28 +39,6 @@ final class TextFieldTypesSpec: QuickSpec {
             }
         }
 
-        describe("#type: password with visibility on") {
-            var iconButtonVisibility: NatIconButton?
-
-            beforeEach {
-                systemUnderTest.configure(type: .password())
-                systemUnderTest.showVisibilityIcon()
-
-                iconButtonVisibility = systemUnderTest.subviews
-                    .compactMap { $0 as? NatIconButton }
-                    .first
-
-                iconButtonVisibility?.gestureRecognizers?.first?.sendGesturesEvents()
-            }
-
-            it("shows password on visibility icon tap") {
-                expect(systemUnderTest.textField.keyboardType).to(equal(UIKeyboardType.default))
-                expect(systemUnderTest.textField.autocorrectionType).to(equal(UITextAutocorrectionType.no))
-                expect(systemUnderTest.textField.autocapitalizationType).to(equal(UITextAutocapitalizationType.none))
-                expect(systemUnderTest.textField.isSecureTextEntry).to(beFalse())
-            }
-        }
-
         describe("#type: name") {
             beforeEach {
                 systemUnderTest.configure(type: .name)

--- a/Tests/Public/Components/Field/TextFieldDelegateTests.swift
+++ b/Tests/Public/Components/Field/TextFieldDelegateTests.swift
@@ -22,30 +22,30 @@ final class TextFieldDelegateTests: XCTestCase {
     }
 
     func test_textFieldDelegate_whenHasDelegateAndCallDidEndEditing_expectInvokeTextFieldDelegate() {
-        sut.textFieldDidEndEditing(sut.textField)
+        delegateMock.textFieldDidEndEditing(sut.textField)
 
         XCTAssertEqual(delegateMock.invokedDidEndEditing.count, 1)
-        XCTAssertEqual(delegateMock.invokedDidEndEditing.field, sut)
+        XCTAssertEqual(delegateMock.invokedDidEndEditing.field, sut.textField)
     }
 
     func test_textFieldDelegate_whenHasDelegateAndCallDidBeginEditing_expectInvokeTextFieldDelegate() {
-        sut.textFieldDidBeginEditing(sut.textField)
+        delegateMock.textFieldDidBeginEditing(sut.textField)
 
         XCTAssertEqual(delegateMock.invokedDidBeginEditing.count, 1)
-        XCTAssertEqual(delegateMock.invokedDidBeginEditing.field, sut)
+        XCTAssertEqual(delegateMock.invokedDidBeginEditing.field, sut.textField)
     }
 
     func test_textFieldDelegate_whenHasDelegateAndCallShouldBeginEditing_expectInvokeTextFieldDelegate() {
-        _ = sut.textFieldShouldBeginEditing(sut.textField)
+        _ = delegateMock.textFieldShouldBeginEditing(sut.textField)
 
         XCTAssertEqual(delegateMock.invokedDidShouldBeginEditing.count, 1)
-        XCTAssertEqual(delegateMock.invokedDidShouldBeginEditing.field, sut)
+        XCTAssertEqual(delegateMock.invokedDidShouldBeginEditing.field, sut.textField)
     }
 
     func test_textFieldDelegate_whenHasDelegateAndCallShouldChangeCharacterInRange_expectInvokeTextFieldDelegate() {
-        _ = sut.textField(sut.textField, shouldChangeCharactersIn: NSRange(), replacementString: "")
+        _ = delegateMock.textField(sut.textField, shouldChangeCharactersIn: NSRange(), replacementString: "")
 
         XCTAssertEqual(delegateMock.invokedTextFieldChangeCharInRange.count, 1)
-        XCTAssertEqual(delegateMock.invokedTextFieldChangeCharInRange.field, sut)
+        XCTAssertEqual(delegateMock.invokedTextFieldChangeCharInRange.field, sut.textField)
     }
 }


### PR DESCRIPTION
# Description

### ⚠️ BREAKING CHANGES:
- Removes old delegate class `TextFieldDelegate` and replaces TextField's delegate with default `UITextFieldDelegate`
- Removes visibility icon on/off configuration for password type textfields, as it's a _pattern_ of use in the Design System's documentation

### Refactor:
- Removes duplicated code moving style-related code to TextField's state enums

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update
- [x] Internal changes
