### PR TITLE
Bugfix: Fix tag visibility for reused cells at navigation drawer

### DIFF
--- a/Sources/Public/Components/NavigationDrawer/NavigationDrawerItemCell.swift
+++ b/Sources/Public/Components/NavigationDrawer/NavigationDrawerItemCell.swift
@@ -26,7 +26,9 @@ public class NavigationDrawerItemCell: UITableViewCell {
     public var tagText: String? {
         didSet {
             if let text = tagText {
+                tagView.setNeedsDisplay()
                 tagView.configure(text: text)
+                tagView.isHidden = false
             } else {
                 tagView.isHidden = true
             }


### PR DESCRIPTION
# Description

- Fix `NatTag` visibility for reused cells at `NavigationDrawer`

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Internal changes
