### PR TITLE
[DSY-2097] Fix visual bug at counter

### DIFF
--- a/NatDS.xcodeproj/project.pbxproj
+++ b/NatDS.xcodeproj/project.pbxproj
@@ -217,6 +217,7 @@
 		7D5F149A25A782AB007986EE /* IconsSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D5F149925A782AB007986EE /* IconsSource.swift */; };
 		7D60A443260914DE00A23C1A /* NatIconButton+Backgrounds.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D60A442260914DE00A23C1A /* NatIconButton+Backgrounds.swift */; };
 		7D60A4A0260E208E00A23C1A /* NatListItem+Feedback.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D60A49F260E208E00A23C1A /* NatListItem+Feedback.swift */; };
+		7D704EDB26AB556100B64226 /* NatCounter+Size+Spec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D704EDA26AB556100B64226 /* NatCounter+Size+Spec.swift */; };
 		7D75A43925DB00130050ACA9 /* NatAvatar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D75A43825DB00130050ACA9 /* NatAvatar.swift */; };
 		7D75A44125DB00230050ACA9 /* NatAvatar+Size.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D75A44025DB00230050ACA9 /* NatAvatar+Size.swift */; };
 		7D86C195266533F600FC4C53 /* NatLogo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D86C194266533F600FC4C53 /* NatLogo.swift */; };
@@ -635,6 +636,7 @@
 		7D5F149925A782AB007986EE /* IconsSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IconsSource.swift; sourceTree = "<group>"; };
 		7D60A442260914DE00A23C1A /* NatIconButton+Backgrounds.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NatIconButton+Backgrounds.swift"; sourceTree = "<group>"; };
 		7D60A49F260E208E00A23C1A /* NatListItem+Feedback.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NatListItem+Feedback.swift"; sourceTree = "<group>"; };
+		7D704EDA26AB556100B64226 /* NatCounter+Size+Spec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NatCounter+Size+Spec.swift"; sourceTree = "<group>"; };
 		7D75A43825DB00130050ACA9 /* NatAvatar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NatAvatar.swift; sourceTree = "<group>"; };
 		7D75A44025DB00230050ACA9 /* NatAvatar+Size.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NatAvatar+Size.swift"; sourceTree = "<group>"; };
 		7D86C194266533F600FC4C53 /* NatLogo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NatLogo.swift; sourceTree = "<group>"; };
@@ -1554,6 +1556,7 @@
 			isa = PBXGroup;
 			children = (
 				79EA0C56260E21E700742C0A /* NatCounter+Spec.swift */,
+				7D704EDA26AB556100B64226 /* NatCounter+Size+Spec.swift */,
 			);
 			path = Counter;
 			sourceTree = "<group>";
@@ -3134,6 +3137,7 @@
 				79FC59D425D57A3F001CCB56 /* ProgressIndicatorCircular+Size+Spec.swift in Sources */,
 				7DE2B10725FBD57300C5CBC0 /* NatListItem+Spec.swift in Sources */,
 				79E7FB3A2538CFA200A831BC /* NaturaLightTokens+Elevation+Spec.swift in Sources */,
+				7D704EDB26AB556100B64226 /* NatCounter+Size+Spec.swift in Sources */,
 				A0328AF2000431B6155A5A6CD94B1835 /* ReusableViewTests.swift in Sources */,
 				79E7FB492538D04300A831BC /* NaturaDarkTokens+Size+Spec.swift in Sources */,
 				84B9330E24ABC6D200B71BD4 /* NatDialogCustomBodyConfigurable+Spec.swift in Sources */,

--- a/NatDSSnapShotTests/Counter/NatCounter+Snapshot+Tests.swift
+++ b/NatDSSnapShotTests/Counter/NatCounter+Snapshot+Tests.swift
@@ -20,7 +20,7 @@ final class NatCounterSnapshotTests: XCTestCase {
         superview.addSubview(systemUnderTest)
         addConstraints(systemUnderTest)
 
-        assertSnapshot(matching: superview, as: .image)
+        assertSnapshot(matching: superview, as: .image(precision: 0.98))
     }
 
     func test_counter_medium_size_hasValidSnapshot() {
@@ -28,7 +28,7 @@ final class NatCounterSnapshotTests: XCTestCase {
         superview.addSubview(systemUnderTest)
         addConstraints(systemUnderTest)
 
-        assertSnapshot(matching: superview, as: .image)
+        assertSnapshot(matching: superview, as: .image(precision: 0.98))
     }
 
     func test_counter_with_label_hasValidSnapshot() {
@@ -37,7 +37,7 @@ final class NatCounterSnapshotTests: XCTestCase {
         superview.addSubview(systemUnderTest)
         addConstraints(systemUnderTest)
 
-        assertSnapshot(matching: superview, as: .image)
+        assertSnapshot(matching: superview, as: .image(precision: 0.98))
     }
 
     func test_counter_add_disabled_hasValidSnapshot() {
@@ -46,7 +46,7 @@ final class NatCounterSnapshotTests: XCTestCase {
         superview.addSubview(systemUnderTest)
         addConstraints(systemUnderTest)
 
-        assertSnapshot(matching: superview, as: .image)
+        assertSnapshot(matching: superview, as: .image(precision: 0.98))
     }
 
     func test_counter_subtract_disabled_hasValidSnapshot() {
@@ -55,7 +55,7 @@ final class NatCounterSnapshotTests: XCTestCase {
         superview.addSubview(systemUnderTest)
         addConstraints(systemUnderTest)
 
-        assertSnapshot(matching: superview, as: .image)
+        assertSnapshot(matching: superview, as: .image(precision: 0.98))
     }
 
     func test_counter_all_buttons_disabled_hasValidSnapshot() {
@@ -64,7 +64,7 @@ final class NatCounterSnapshotTests: XCTestCase {
         superview.addSubview(systemUnderTest)
         addConstraints(systemUnderTest)
 
-        assertSnapshot(matching: superview, as: .image)
+        assertSnapshot(matching: superview, as: .image(precision: 0.98))
     }
 
     private func addConstraints(_ systemUnderTest: UIView) {

--- a/Sources/Public/Components/Counter/NatCounter+Size.swift
+++ b/Sources/Public/Components/Counter/NatCounter+Size.swift
@@ -28,6 +28,10 @@ extension NatCounter.Size {
         }
     }
 
+    var borderRadius: CGFloat {
+        return getTokenFromTheme(\.borderRadiusMedium)
+    }
+
     var buttonWidth: CGFloat {
         switch self {
         case .semi:

--- a/Sources/Public/Components/Counter/NatCounter+Size.swift
+++ b/Sources/Public/Components/Counter/NatCounter+Size.swift
@@ -27,4 +27,22 @@ extension NatCounter.Size {
             return getTokenFromTheme(\.sizeMedium)
         }
     }
+
+    var buttonWidth: CGFloat {
+        switch self {
+        case .semi:
+            return getTokenFromTheme(\.sizeSemi)
+        case .medium:
+            return getTokenFromTheme(\.sizeSemiX)
+        }
+    }
+
+    var buttonHeight: CGFloat {
+        switch self {
+        case .semi:
+            return getTokenFromTheme(\.sizeSemiX)
+        case .medium:
+            return getTokenFromTheme(\.sizeMedium)
+        }
+    }
 }

--- a/Sources/Public/Components/Counter/NatCounter.swift
+++ b/Sources/Public/Components/Counter/NatCounter.swift
@@ -98,7 +98,7 @@ public final class NatCounter: UIView {
 
     let subtractView: NatCounterButton = {
         let view = NatCounterButton()
-        view.configure(iconLabel: "-")
+        view.iconLabel.text = "-"
         view.translatesAutoresizingMaskIntoConstraints = false
 
         return view
@@ -106,13 +106,13 @@ public final class NatCounter: UIView {
 
     let addView: NatCounterButton = {
         let view = NatCounterButton()
-        view.configure(iconLabel: "+")
+        view.iconLabel.text = "+"
         view.translatesAutoresizingMaskIntoConstraints = false
 
         return view
     }()
 
-    internal var size: Size
+    private var size: Size
 
     // MARK: - Inits
 
@@ -214,11 +214,11 @@ public final class NatCounter: UIView {
                              sizeWidth: size.buttonWidth,
                              sizeHeight: size.buttonHeight)
 
-        subtractView.configure {
+        subtractView.action = {
             self.numCounter -= 1
         }
 
-        addView.configure {
+        addView.action = {
             self.numCounter += 1
         }
     }

--- a/Sources/Public/Components/Counter/NatCounterButton.swift
+++ b/Sources/Public/Components/Counter/NatCounterButton.swift
@@ -1,8 +1,8 @@
 import UIKit
 
-final class NatCounterButton: UIView, Pulsable {
+internal final class NatCounterButton: UIView, Pulsable {
 
-    private var action: (() -> Void)?
+    var action: (() -> Void)?
     var isEnabled: Bool = true {
         didSet {
             self.updateColors()
@@ -10,7 +10,7 @@ final class NatCounterButton: UIView, Pulsable {
         }
     }
 
-    internal let iconLabel: UILabel = {
+    var iconLabel: UILabel = {
         let label = UILabel()
         label.font = NatFonts.font(ofSize: .button, withWeight: .medium)
         label.translatesAutoresizingMaskIntoConstraints = false
@@ -55,15 +55,7 @@ final class NatCounterButton: UIView, Pulsable {
             getUIColorFromTokens(\.colorMediumEmphasis)
     }
 
-    internal func configure(action: @escaping () -> Void) {
-        self.action = action
-    }
-
-    internal func configure(iconLabel: String?) {
-        self.iconLabel.text = iconLabel
-    }
-
-    internal func configure(height: CGFloat, width: CGFloat) {
+    func configure(height: CGFloat, width: CGFloat) {
         NSLayoutConstraint.activate([
             heightAnchor.constraint(equalToConstant: height),
             widthAnchor.constraint(equalToConstant: width)
@@ -76,7 +68,7 @@ final class NatCounterButton: UIView, Pulsable {
         }
     }
 
-    internal override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
+    override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
         super.touchesBegan(touches, with: event)
         if isEnabled {
             let color = getUIColorFromTokens(\.colorHighEmphasis).withAlphaComponent(0.2)

--- a/Sources/Public/Components/Counter/NatCounterButton.swift
+++ b/Sources/Public/Components/Counter/NatCounterButton.swift
@@ -1,18 +1,18 @@
 import UIKit
 
 final class NatCounterButton: UIView, Pulsable {
-    public enum State {
-        case enabled
-        case disabled
-    }
 
     private var action: (() -> Void)?
-    internal var currentState: State = .enabled
+    var isEnabled: Bool = true {
+        didSet {
+            self.updateColors()
+            self.setNeedsDisplay()
+        }
+    }
 
     internal let iconLabel: UILabel = {
         let label = UILabel()
         label.font = NatFonts.font(ofSize: .button, withWeight: .medium)
-        label.textColor = getUIColorFromTokens(\.colorHighEmphasis)
         label.translatesAutoresizingMaskIntoConstraints = false
 
         return label
@@ -49,6 +49,12 @@ final class NatCounterButton: UIView, Pulsable {
         addGestureRecognizer(tapGesture)
     }
 
+    private func updateColors() {
+        self.iconLabel.textColor = isEnabled ?
+            getUIColorFromTokens(\.colorHighEmphasis) :
+            getUIColorFromTokens(\.colorMediumEmphasis)
+    }
+
     internal func configure(action: @escaping () -> Void) {
         self.action = action
     }
@@ -65,21 +71,22 @@ final class NatCounterButton: UIView, Pulsable {
     }
 
     @objc func tapHandler(_ sender: UIGestureRecognizer) {
-        guard currentState == .enabled else { return }
-        action?()
+        if isEnabled {
+            action?()
+        }
     }
 
     internal override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
         super.touchesBegan(touches, with: event)
-        guard currentState == .enabled else { return }
+        if isEnabled {
+            let color = getUIColorFromTokens(\.colorHighEmphasis).withAlphaComponent(0.2)
 
-        let color = getUIColorFromTokens(\.colorHighEmphasis).withAlphaComponent(0.2)
-
-        addPulseLayerAnimated(
-            at: centerBounds,
-            in: layer,
-            withColor: color,
-            removeAfterAnimation: true
-        )
+            addPulseLayerAnimated(
+                at: centerBounds,
+                in: layer,
+                withColor: color,
+                removeAfterAnimation: true
+            )
+        }
     }
 }

--- a/Tests/Public/Components/Counter/NatCounter+Size+Spec.swift
+++ b/Tests/Public/Components/Counter/NatCounter+Size+Spec.swift
@@ -1,0 +1,26 @@
+import Quick
+import Nimble
+
+@testable import NatDS
+
+final class NatCounterSizeSpec: QuickSpec {
+    override func spec() {
+        let systemUnderTest = NatCounter.Size.self
+
+        beforeEach {
+            ConfigurationStorage.shared.currentTheme = StubTheme()
+        }
+
+        describe("#semi") {
+            it("returns expected height") {
+                expect(systemUnderTest.semi.value).to(equal(getTokenFromTheme(\.sizeSemi)))
+            }
+        }
+
+        describe("#medium") {
+            it("returns expected height") {
+                expect(systemUnderTest.medium.value).to(equal(getTokenFromTheme(\.sizeMedium)))
+            }
+        }
+    }
+}

--- a/Tests/Public/Components/Counter/NatCounter+Spec.swift
+++ b/Tests/Public/Components/Counter/NatCounter+Spec.swift
@@ -62,20 +62,20 @@ final class NatCounterSpec: QuickSpec {
                 it("when subtract button is disabled") {
                     let state = NatCounter.State.self
                     sut.configure(button: .subtract, state: .disabled)
-                    expect(sut.subtractView.currentState.hashValue).to(equal(state.disabled.hashValue))
+                    expect(sut.subtractView.isEnabled).to(beFalse())
                 }
 
                 it("when add button is disabled") {
                     let state = NatCounter.State.self
                     sut.configure(button: .add, state: .disabled)
-                    expect(sut.addView.currentState.hashValue).to(equal(state.disabled.hashValue))
+                    expect(sut.addView.isEnabled).to(beFalse())
                 }
 
                 it("when all buttons are disabled") {
                     let state = NatCounter.State.self
                     sut.configure(button: .all, state: .disabled)
-                    expect(sut.addView.currentState.hashValue).to(equal(state.disabled.hashValue))
-                    expect(sut.subtractView.currentState.hashValue).to(equal(state.disabled.hashValue))
+                    expect(sut.addView.isEnabled).to(beFalse())
+                    expect(sut.subtractView.isEnabled).to(beFalse())
                 }
             }
 
@@ -89,20 +89,20 @@ final class NatCounterSpec: QuickSpec {
                 it("when subtract button is enabled") {
                     let state = NatCounter.State.self
                     sut.configure(button: .subtract, state: .enabled)
-                    expect(sut.subtractView.currentState.hashValue).to(equal(state.enabled.hashValue))
+                    expect(sut.subtractView.isEnabled).to(beTrue())
                 }
 
                 it("when add button is enabled") {
                     let state = NatCounter.State.self
                     sut.configure(button: .add, state: .enabled)
-                    expect(sut.addView.currentState.hashValue).to(equal(state.enabled.hashValue))
+                    expect(sut.addView.isEnabled).to(beTrue())
                 }
 
                 it("when all buttons are enabled") {
                     let state = NatCounter.State.self
                     sut.configure(button: .all, state: .enabled)
-                    expect(sut.addView.currentState.hashValue).to(equal(state.enabled.hashValue))
-                    expect(sut.subtractView.currentState.hashValue).to(equal(state.enabled.hashValue))
+                    expect(sut.addView.isEnabled).to(beTrue())
+                    expect(sut.subtractView.isEnabled).to(beTrue())
                 }
             }
         }

--- a/Tests/Public/Components/Counter/NatCounter+Spec.swift
+++ b/Tests/Public/Components/Counter/NatCounter+Spec.swift
@@ -17,21 +17,6 @@ final class NatCounterSpec: QuickSpec {
                 sut = NatCounter()
                 expect(sut.numCounterLabel.text).to(equal("0"))
             }
-
-            it("size default") {
-                sut = NatCounter()
-                expect(sut.size.value).to(equal(NatSizes.semi))
-            }
-
-            it("size semi") {
-                sut = NatCounter(size: .semi)
-                expect(sut.size.value).to(equal(NatSizes.semi))
-            }
-
-            it("size medium") {
-                sut = NatCounter(size: .medium)
-                expect(sut.size.value).to(equal(NatSizes.medium))
-            }
         }
 
         describe("#configure(label:)") {
@@ -60,19 +45,16 @@ final class NatCounterSpec: QuickSpec {
                 }
 
                 it("when subtract button is disabled") {
-                    let state = NatCounter.State.self
                     sut.configure(button: .subtract, state: .disabled)
                     expect(sut.subtractView.isEnabled).to(beFalse())
                 }
 
                 it("when add button is disabled") {
-                    let state = NatCounter.State.self
                     sut.configure(button: .add, state: .disabled)
                     expect(sut.addView.isEnabled).to(beFalse())
                 }
 
                 it("when all buttons are disabled") {
-                    let state = NatCounter.State.self
                     sut.configure(button: .all, state: .disabled)
                     expect(sut.addView.isEnabled).to(beFalse())
                     expect(sut.subtractView.isEnabled).to(beFalse())
@@ -87,19 +69,16 @@ final class NatCounterSpec: QuickSpec {
                 }
 
                 it("when subtract button is enabled") {
-                    let state = NatCounter.State.self
                     sut.configure(button: .subtract, state: .enabled)
                     expect(sut.subtractView.isEnabled).to(beTrue())
                 }
 
                 it("when add button is enabled") {
-                    let state = NatCounter.State.self
                     sut.configure(button: .add, state: .enabled)
                     expect(sut.addView.isEnabled).to(beTrue())
                 }
 
                 it("when all buttons are enabled") {
-                    let state = NatCounter.State.self
                     sut.configure(button: .all, state: .enabled)
                     expect(sut.addView.isEnabled).to(beTrue())
                     expect(sut.subtractView.isEnabled).to(beTrue())


### PR DESCRIPTION
# Description

- Fixed bug that used to hide the corners of the `NatCounter` add and subtract buttons, at `iOS 11.4`
- Changed precision to the snapshot tests because of a [bug](https://github.com/pointfreeco/swift-snapshot-testing/issues/358) with the `SnapshotTesting` library

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Internal changes
