### PR TITLE
fix: update button typography token deprecation to fix cocoapods release

### DIFF
--- a/Sources/Core/Theme/SingleSourceOfTruth/BrandsThemes/Natura/NaturaDarkTheme.swift
+++ b/Sources/Core/Theme/SingleSourceOfTruth/BrandsThemes/Natura/NaturaDarkTheme.swift
@@ -271,4 +271,3 @@ struct NaturaDarkComponents: Components {
     let overlineFontWeight: UIFont.Weight = .medium
     let overlineLetterSpacing: CGFloat = 0.8
 }
-

--- a/Sources/Public/DesignTokens/NatFonts/NatFonts+TextStyle.swift
+++ b/Sources/Public/DesignTokens/NatFonts/NatFonts+TextStyle.swift
@@ -67,7 +67,6 @@ extension NatFonts.TextStyle {
         letterSpacing: getComponentAttributeFromTheme(\.body2LetterSpacing)
     )
 
-    @available(*, deprecated, message: "This token is deprecated")
     static let button: NatFonts.TextStyle = .init(
         size: getComponentAttributeFromTheme(\.buttonDefaultFontSize),
         weight: getComponentAttributeFromTheme(\.buttonDefaultFontWeight),

--- a/Sources/Public/DesignTokens/NatFonts/NatFonts.swift
+++ b/Sources/Public/DesignTokens/NatFonts/NatFonts.swift
@@ -82,6 +82,7 @@ extension NatFonts {
         case subtitle2
         case body1
         case body2
+        @available(*, deprecated, message: "Button token is deprecated")
         case button
         case caption
         case overline


### PR DESCRIPTION
# Description

- Fixed warning at `button` typography token caused by deprecation. This warning was blocking release to Cocoapods.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Internal changes
