### PR TITLE
[DSY-2427] Fix editing textfield with feedback state

### DIFF
--- a/Sources/Public/Components/Field/TextField.swift
+++ b/Sources/Public/Components/Field/TextField.swift
@@ -384,7 +384,7 @@ extension TextField {
     }
 
     private func handleInteractionAndFeedbackStyle() {
-        if state == .none || isEditing {
+        if state == .none {
             textField.borderWidth = interactionState.borderWidth
             textField.borderColor = interactionState.borderColor
             textField.textColor = interactionState.textColor


### PR DESCRIPTION
# Description

- Fix bug that made `Text Field` look like 'active' when editing in 'error' state

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Internal changes
