### PR TITLE
[DSY-2411] Deprecates value text highlight

### DIFF
--- a/Sources/Public/Components/ValueText/ValueTextHighlight.swift
+++ b/Sources/Public/Components/ValueText/ValueTextHighlight.swift
@@ -19,7 +19,7 @@ import Foundation
  */
 
 // swiftlint:disable line_length
-@available(*, deprecated, message: "This component is deprecated since version 6.18.0 and will not receive new updates and maintenance.")
+@available(*, deprecated, message: "This component is deprecated since version 6.18.0 and will no longer receive updates and fixes.")
 // swiftlint:enable line_length
 public class ValueTextHighlight: UIView {
 

--- a/Sources/Public/Components/ValueText/ValueTextHighlight.swift
+++ b/Sources/Public/Components/ValueText/ValueTextHighlight.swift
@@ -1,7 +1,12 @@
 import Foundation
 /**
- ValueTextHighlight is a class that represents a component from the design system.
+ - NOTE:
+ The component Value Text Highlight is deprecated since NatDS version `6.18.0`.
+ It won't be updated or receive maintenance.
  
+ ---
+ 
+ ValueTextHighlight is a class that represents a component from the design system.
  Example of usage:
  
         valueTextHighlight.valueDescription = "Amount value"
@@ -13,6 +18,9 @@ import Foundation
         DesignSystem().configure(with: AvailableTheme)
  */
 
+// swiftlint:disable line_length
+@available(*, deprecated, message: "This component is deprecated since version 6.18.0 and will not receive new updates and maintenance.")
+// swiftlint:enable line_length
 public class ValueTextHighlight: UIView {
 
     public var valueDescription: String? {


### PR DESCRIPTION
# Description

- Deprecates `Value Text Highlight` component, which will no longer receive updates and fixes.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update
- [x] Internal changes
