### PR TITLE
[DSY-2480] Fix send to prod script to allow deprecation

### DIFF
--- a/Sources/Public/Components/Rating/NatRating+Style.swift
+++ b/Sources/Public/Components/Rating/NatRating+Style.swift
@@ -38,7 +38,7 @@ extension NatRating {
                 let fontSize = getComponentAttributeFromTheme(\.ratingCounterLabelFontSize)
                 let fontWeight = getComponentAttributeFromTheme(\.ratingCounterLabelPrimaryFontWeight)
                 let fontFamily = getComponentAttributeFromTheme(\.ratingCounterLabelPrimaryFontFamily)
-                
+
                 return NatFonts.font(ofSize: fontSize,
                                      withWeight: fontWeight,
                                      withFamily: fontFamily)
@@ -46,7 +46,7 @@ extension NatRating {
                 let fontSize = getComponentAttributeFromTheme(\.ratingInputLabelFontSize)
                 let fontWeight = getComponentAttributeFromTheme(\.ratingInputLabelPrimaryFontWeight)
                 let fontFamily = getComponentAttributeFromTheme(\.ratingInputLabelPrimaryFontFamily)
-                
+
                 return NatFonts.font(ofSize: fontSize,
                                      withWeight: fontWeight,
                                      withFamily: fontFamily)

--- a/scripts/bump_version.sh
+++ b/scripts/bump_version.sh
@@ -17,7 +17,7 @@ then
     git add Tests/Supporting\ Files/Info.plist
     git commit -m "chore: updates version on Info.plist files"
     git push --follow-tags origin HEAD
-    VERSION_NUMBER=$VERSION pod trunk push NatDS.podspec
+    VERSION_NUMBER=$VERSION pod trunk push NatDS.podspec --allow-warnings
     make teams_release_notification
 else
     echo "No applicable changes since the previous tag, skipping..."


### PR DESCRIPTION
# Description

- Update script that sends NatDS to prod to allow deprecation warnings at Cocoapods

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Internal changes
