### PR TITLE
[DSY-2490] Change icon button's action configuration to fix retain cycle

### DIFF
--- a/Sources/Public/Components/IconButton/NatIconButton.swift
+++ b/Sources/Public/Components/IconButton/NatIconButton.swift
@@ -160,8 +160,8 @@ extension NatIconButton {
 
     /// Sets the functionality for the icon button. Example:
     ///
-    ///     iconButtonDefaultStyle.configure(delegate: self) { (self) in
-    ///         // your code
+    ///     yourIconButton.configure(delegate: self) { (self) in
+    ///         // your code for icon button's tap
     ///     }
     ///
     /// - Parameters:

--- a/Sources/Public/Components/IconButton/NatIconButton.swift
+++ b/Sources/Public/Components/IconButton/NatIconButton.swift
@@ -114,7 +114,7 @@ public final class NatIconButton: UIView {
 
     @objc func tapHandler(_ sender: UIGestureRecognizer) {
         guard currentState == .enabled else { return }
-        action?()
+        self.action?()
         removePulseLayer(layer: layer)
     }
 
@@ -153,10 +153,26 @@ public final class NatIconButton: UIView {
 
 extension NatIconButton {
 
-    /// Sets the functionality for the icon button
-    /// - Parameter action: A block of functionality to be executed when the icon button is pressed
+    @available(*, deprecated, message: "Use configure(delegate:, action:) instead")
     public func configure(action: @escaping () -> Void) {
         self.action = action
+    }
+
+    /// Sets the functionality for the icon button. Example:
+    ///
+    ///     iconButtonDefaultStyle.configure(delegate: self) { (self) in
+    ///         // your code
+    ///     }
+    ///
+    /// - Parameters:
+    ///   - delegate: the class that is the delegate for the action (usually, the class itself)
+    ///   - action: a block of code to be run when the icon button is pressed
+    public func configure<Object: AnyObject>(delegate: Object, action: @escaping (Object) -> Void) {
+        self.action = { [weak delegate] in
+            if let delegate = delegate {
+                action(delegate)
+            }
+        }
     }
 
     @available(*, deprecated, message: "Use configure(badge:) instead")


### PR DESCRIPTION
# Description

- Update `Icon Button` action configuration method to prevent retain cycles
- Deprecate old action configuration method

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Internal changes
