### PR TITLE
[DSY-2241] Update AppBarTop with logo

### DIFF
--- a/SampleApp/Sources/Sample/Components/AppBar/AppBarDataSource.swift
+++ b/SampleApp/Sources/Sample/Components/AppBar/AppBarDataSource.swift
@@ -22,7 +22,7 @@ enum AppBarSection: CaseIterable {
         case .action:
             return [.oneActionRight, .threeActionsRight, .oneActionLeft]
         case .contentType:
-            return [.text, .media]
+            return [.text, .media, .logo]
         }
     }
 }
@@ -39,6 +39,7 @@ enum AppBarItem {
     case oneActionLeft
     case text
     case media
+    case logo
 
     var title: String {
         switch self {
@@ -53,6 +54,7 @@ enum AppBarItem {
         case .oneActionLeft: return "Action Left"
         case .text: return "Content type: Text"
         case .media: return "Content type: Media"
+        case .logo: return "Content type: Logo"
         }
     }
 }

--- a/SampleApp/Sources/Sample/Components/AppBar/AppBarDetailViewController.swift
+++ b/SampleApp/Sources/Sample/Components/AppBar/AppBarDetailViewController.swift
@@ -85,11 +85,11 @@ class AppBarDetailViewController: UITableViewController, UITextFieldDelegate {
         case .text:
             self.configure(appBarContentType: .text("Text Content Type"))
         case .media:
-            let image = NatLogoImages.horizontal
+            let image = UIImage(named: "ImageAreaPlaceholder")
             self.configure(appBarContentType: .media(image))
         case .logo:
-            let myLogo = NatLogo(size: .largeXXX)
-            self.configure(appBarContentType: .logo(myLogo))
+            let newLogo = NatLogo(size: .largeXXX)
+            self.configure(appBarContentType: .logo(newLogo))
         }
     }
 

--- a/SampleApp/Sources/Sample/Components/AppBar/AppBarDetailViewController.swift
+++ b/SampleApp/Sources/Sample/Components/AppBar/AppBarDetailViewController.swift
@@ -87,6 +87,9 @@ class AppBarDetailViewController: UITableViewController, UITextFieldDelegate {
         case .media:
             let image = NatLogoImages.horizontal
             self.configure(appBarContentType: .media(image))
+        case .logo:
+            let myLogo = NatLogo(size: .largeXXX)
+            self.configure(appBarContentType: .logo(myLogo))
         }
     }
 

--- a/Sources/Public/Components/AppBar/AppBarContentType.swift
+++ b/Sources/Public/Components/AppBar/AppBarContentType.swift
@@ -3,4 +3,5 @@
 public enum AppBarContentType {
     case text(String)
     case media(UIImage?)
+    case logo(NatLogo)
 }

--- a/Sources/Public/Components/AppBar/UIViewController+Configure.swift
+++ b/Sources/Public/Components/AppBar/UIViewController+Configure.swift
@@ -41,7 +41,7 @@ public extension UIViewController {
     }
 
     /// Sets the content type for the navigation bar's center view
-    /// - Parameter item: an option from `AppBarContentType`, with a string value (for text) or an image (for media)
+    /// - Parameter item: an option from `AppBarContentType`, with a string value (for text), an image (for media) or a `NatLogo`
     func configure(appBarContentType item: AppBarContentType) {
         switch item {
         case .media(let image):
@@ -53,6 +53,11 @@ public extension UIViewController {
         case .text(let string):
             navigationItem.titleView = nil
             title = string
+        case .logo(let logo):
+            logo.translatesAutoresizingMaskIntoConstraints = false
+            logo.widthAnchor.constraint(lessThanOrEqualToConstant: NatSizes.hugeX).isActive = true
+            logo.contentMode = .scaleAspectFit
+            navigationItem.titleView = logo
         }
     }
 

--- a/Tests/Public/Components/AppBar/UIViewController+Configure+Spec.swift
+++ b/Tests/Public/Components/AppBar/UIViewController+Configure+Spec.swift
@@ -29,16 +29,29 @@ final class UIViewControllerConfigureSpec: QuickSpec {
 
             context("when appBarContentType is .media") {
                 beforeEach {
-                    sut.configure(appBarContentType: .media(NatLogoImages.horizontal))
+                    sut.configure(appBarContentType: .media(UIImage()))
+                }
+                it("sets navigationItem titleView") {
+                    expect(sut.navigationItem.titleView).toNot(beNil())
+                }
+                it("sets navigationItem titleView with image and its not nil") {
+                    let imageView = sut.navigationItem.titleView as? UIImageView
+
+                    expect(imageView?.image).toNot(beNil())
+                }
+            }
+
+            context("when appBarContentType is .logo") {
+                beforeEach {
+                    sut.configure(appBarContentType: .logo(NatLogo()))
                 }
                 it("sets navigationItem titleView") {
                     expect(sut.navigationItem.titleView).toNot(beNil())
                 }
                 it("sets navigationItem titleView with logo") {
-                    let logoImageView = sut.navigationItem.titleView as? UIImageView
-                    let logoImage = logoImageView?.image
+                    let logoImage = sut.navigationItem.titleView as? NatLogo
 
-                    expect(logoImage).to(equal(NatLogoImages.horizontal))
+                    expect(logoImage).to(beAKindOf(NatLogo.self))
                 }
             }
         }


### PR DESCRIPTION
# Description

- Add method to set a `NatLogo` as the center view of the `App Bar Top` component (navigation bar).

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Internal changes
