### PR TITLE
[DSY-2138] Deprecate old buttons config method at app bar top

### DIFF
--- a/Sources/Public/Components/AppBar/UIViewController+Configure.swift
+++ b/Sources/Public/Components/AppBar/UIViewController+Configure.swift
@@ -70,6 +70,7 @@ public extension UIViewController {
     ///             viewController.configure(buttons: barItems)
     ///
     /// - Parameter buttons: an array of UIBarButtonItems
+    @available(*, deprecated, message: "Use configure(appBarActionRight items:) instead")
     func configure(buttons: [UIBarButtonItem]) {
         let itemButtons = setSpacingBetween(buttons: buttons)
         navigationItem.setRightBarButtonItems(itemButtons, animated: true)


### PR DESCRIPTION
# Description

- Deprecate method `configure(buttons: [UIBarButtonItem])` for `App Bar Top` configuration. It was replaced by the method `configure(appBarActionRight items: [UIView])`, which accepts any views and display them as buttons.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Internal changes
